### PR TITLE
Level 1 Entire Core Phase

### DIFF
--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -85,9 +85,13 @@ With Level 3, the submitter need not be concerned about different types of compu
 Level 2 submissions include the average power during the core phase of the run and the average power during the full run.
 
 The complete set of power-averaged measurements used to calculate average power must also be provided. 
-Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for the definition of a power-averaged measurement and how it differs from a total energy measurement.
+Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for the definition of a power-averaged
+measurement and how it differs from a total energy measurement.
 
-For Level 2, the workload run must have a series of equally spaced power-averaged measurements of equal length. These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload. The reported average power for the core phase of the run is the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.
+For Level 2, the workload run must have a series of equally spaced power-averaged measurements of equal length.
+These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the
+core phase of the workload. The reported average power for the core phase of the run is the numerical average of the
+10 (or more) power-averaged measurements collected during the core phase.
 
 Each of the required equally spaced measurements required for L2 must power-average over the entire separating space. 
 
@@ -106,26 +110,30 @@ The compute-node subsystem is the set of compute nodes. As with Level 1, if the 
 \textbf{Level 1 Power Measurement}
 \addcontentsline{toc}{subsection}{Level 1 Power Measurement}
 
-Level 1 requires at least one power-averaged measurement during the run. Refer to 
-Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for the definition of a power-averaged measurement and how it differs from a total energy measurement.
+Level 1 submissions submissions include the average power during the core phase of the run.
 
-The total interval covered must be at least 20\% of the core phase of the run or one minute, whichever is {\itshape longer\/}. 
+The complete set of power-averaged measurements used to calculate average power must also be provided.
+Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for the definition of a power-averaged measurement
+and how it differs from a total energy measurement.
 
-If the choice is one minute (because it's longer than 20\% of the core phase) that minute must reside in the middle 80\% of the core phase. If the middle 80\% of the core phase is less than one minute, the measurement must include the entire middle 80\% and overlap equally on both sides.
+For Level 1, the workload run must have a series of equally spaced power-averaged measurements of equal length.
+These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the
+core phase of the workload. The reported average power for the core phase of the run is the numerical average of the
+10 (or more) power-averaged measurements collected during the core phase.
 
-If the choice is 20\% of the core phase (because this 20\% is greater than one minute), this 20\% must reside in the middle 80\% of the core phase.
+Each of the required equally spaced measurements required for L2 must power-average over the entire separating space.
 
-Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 1 power submission.
+Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the
+Level 1 power submission.
 
 For Level 1, both the compute-node subsystem and the interconnect must be reported.  
 The compute-node subsystem power must be measured. 
-Measure a minimum of 2kw of power, 
+For the compute subsystem measure a minimum of 2kw of power, 
 10\% of the system, or 15  nodes whichever is largest, or the whole machine if smaller than the largest requirement.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
 This may include infrastructure that is shared, but excludes that part that is not servicing the current cluster.
-
 
 For some systems, it may be impossible not to include a power contribution from some subsystems. 
 In this case, list what you are including, but do not subtract an estimated value for the included subsystem.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -88,7 +88,7 @@ The complete set of power-averaged measurements used to calculate average power 
 Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for the definition of a power-averaged
 measurement and how it differs from a total energy measurement.
 
-For Level 2, the workload run must have a series of equally spaced power-averaged measurements of equal length.
+For Level 2, the workload run must have a series of equally spaced power-averaged measurements of equal length, sampled at least once per second.
 These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the
 core phase of the workload. The reported average power for the core phase of the run is the numerical average of the
 10 (or more) power-averaged measurements collected during the core phase.
@@ -110,18 +110,10 @@ The compute-node subsystem is the set of compute nodes. As with Level 1, if the 
 \textbf{Level 1 Power Measurement}
 \addcontentsline{toc}{subsection}{Level 1 Power Measurement}
 
-Level 1 submissions submissions include the average power during the core phase of the run.
+Level 1 submissions submissions include the average power over the entire core phase of the run.
 
-The complete set of power-averaged measurements used to calculate average power must also be provided.
-Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for the definition of a power-averaged measurement
-and how it differs from a total energy measurement.
-
-For Level 1, the workload run must have a series of equally spaced power-averaged measurements of equal length.
-These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the
-core phase of the workload. The reported average power for the core phase of the run is the numerical average of the
-10 (or more) power-averaged measurements collected during the core phase.
-
-Each of the required equally spaced measurements required for L2 must power-average over the entire separating space.
+For Level 1, the power must be sampled at least once per second and averaged over the entire core phase to produce the reported average power.
+The core phase is required to run for at least one minute, or the sampling rate must be such that at least 60 samples are produced during the core phase.
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the
 Level 1 power submission.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -113,7 +113,7 @@ The compute-node subsystem is the set of compute nodes. As with Level 1, if the 
 Level 1 submissions submissions include the average power over the entire core phase of the run.
 
 For Level 1, the power must be sampled at least once per second and averaged over the entire core phase to produce the reported average power.
-The core phase is required to run for at least one minute, or the sampling rate must be such that at least 60 samples are produced during the core phase.
+The core phase is required to run for at least one minute.
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the
 Level 1 power submission.

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -119,7 +119,7 @@ Continuously integrated energy\\
 
 
 \textbf{1b:~Timing} &
-The longer of one minute or the entire core phase of the run &
+The entire core phase of the run, at least one minute &
 Equally spaced across the full run &
 Equally spaced across the full run   \\
 \hline
@@ -267,7 +267,8 @@ The device measurement granularity must be at least one instantaneous measuremen
 
 \noindent
 There must be at least one power-averaged measurement during the run.
-The total interval covered must be the core phase of the run or one minute, whichever is longer.
+The total interval covered must be the core phase of the run which must be at
+least one minute long.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -65,7 +65,10 @@ The reported power values for Levels 1 and 2 are power-averaged measurements. A 
 \wl
 
 \noindent
-Consider Level 1, which requires only one reported power value. This reported power value may consist of several power measurements taken at a frequency of at least once per second and averaged over an interval. That interval must be at least 20\% of the run or one minute, whichever is longer. For example, if power measurements may be taken once per second for one minute for a total of 60 power measurements and then averaged, Level 1 reports one power-averaged value.
+Consider Level 1, which requires only one reported power value. 
+This reported power value may consist of several power measurements taken at a frequency of at least once per second and averaged over an interval. 
+That interval must cover the entire core phase of the run or one minute, whichever is longer.
+For example, if power measurements may be taken once per second for one minute for a total of 60 power measurements and then averaged, Level 1 reports one power-averaged value.
 \wl
 
 \noindent
@@ -116,7 +119,7 @@ Continuously integrated energy\\
 
 
 \textbf{1b:~Timing} &
-The longer of one minute or 20\% of the run &
+The longer of one minute or the entire core phase of the run &
 Equally spaced across the full run &
 Equally spaced across the full run   \\
 \hline
@@ -264,11 +267,11 @@ The device measurement granularity must be at least one instantaneous measuremen
 
 \noindent
 There must be at least one power-averaged measurement during the run.
-The total interval covered must be at least 20\% of the core phase of the run or one minute, whichever is longer. The power-averaged measurement must be taken within the middle 80\% of the core phase of the benchmark.  
+The total interval covered must be the core phase of the run or one minute, whichever is longer.
 \wl
 
 \noindent
-Figure~\ref{fig:a1l1pm} illustrates Aspect 1 Level 1 power measurement. If the minimum timespan turns out to be one minute, that minute must reside in the middle 80\% of the core phase. If, as required, the instantaneous measurement must be at least once per second and you are measuring for one minute, you have taken at least 60 instantaneous measurements and averaged them.
+Figure~\ref{fig:a1l1pm} illustrates Aspect 1 Level 1 power measurement. If, as required, the instantaneous measurement must be at least once per second and you are measuring for one minute, you have taken at least 60 instantaneous measurements and averaged them.
 
 %INCLUDE FIG 3-3
 \begin{figure}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -67,7 +67,7 @@ The reported power values for Levels 1 and 2 are power-averaged measurements. A 
 \noindent
 Consider Level 1, which requires only one reported power value. 
 This reported power value may consist of several power measurements taken at a frequency of at least once per second and averaged over an interval. 
-That interval must cover the entire core phase of the run or one minute, whichever is longer.
+That interval must cover the entire core phase of the run which must be at least one minute long.
 For example, if power measurements may be taken once per second for one minute for a total of 60 power measurements and then averaged, Level 1 reports one power-averaged value.
 \wl
 


### PR DESCRIPTION
Deleted all text in checklist referring to Level 1 allowing for 20% of the middle 80% of the core phase.  Mirrored Level 2 requirement in Level 1 that requires measuring average power over the entire core phase and reporting at least 10 measurements.