### PR TITLE
Level 1 Fraction of the System

### DIFF
--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -123,7 +123,7 @@ Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported M
 For Level 1, the only subsystem included in the power measurement is the compute-node subsystem. 
 The compute-node subsystem is the set of compute nodes. 
 Measure a minimum of 2kw of power, 
-10% of the system, or 12  nodes whichever is largest, or the whole machine if smaller than the largest requirement.
+10\% of the system, or 12  nodes whichever is largest, or the whole machine if smaller than the largest requirement.
 
 List any other subsystems that contribute to the workload, but do not provide estimated values for their contribution.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -123,7 +123,7 @@ Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported M
 For Level 1, the only subsystem included in the power measurement is the compute-node subsystem. 
 The compute-node subsystem is the set of compute nodes. 
 Measure a minimum of 2kw of power, 
-10\% of the system, or 12  nodes whichever is largest, or the whole machine if smaller than the largest requirement.
+10\% of the system, or 15  nodes whichever is largest, or the whole machine if smaller than the largest requirement.
 
 List any other subsystems that contribute to the workload, but do not provide estimated values for their contribution.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -120,7 +120,10 @@ If the choice is 20\% of the core phase (because this 20\% is greater than one m
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 1 power submission.
 
-For Level 1, the only subsystem included in the power measurement is the compute-node subsystem. The compute-node subsystem is the set of compute nodes. Measure the greater of $ \frac{1}{64} $ of the compute-node subsystem or 1kW of power.
+For Level 1, the only subsystem included in the power measurement is the compute-node subsystem. 
+The compute-node subsystem is the set of compute nodes. 
+Measure a minimum of 2kw of power, 
+10% of the system, or 12  nodes whichever is largest, or the whole machine if smaller than the largest requirement.
 
 List any other subsystems that contribute to the workload, but do not provide estimated values for their contribution.
 


### PR DESCRIPTION
Deleted the sentence requiring at least 1/64 of the system.  Added a requirement to measure a minimum of 2kw of power, 10% of the system, or 12  nodes whichever is largest, or the whole machine if smaller than the largest requirement.