### PR TITLE
Level 1 Interconnect

### DIFF
--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -120,9 +120,15 @@ If the choice is 20\% of the core phase (because this 20\% is greater than one m
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 1 power submission.
 
-For Level 1, the only subsystem included in the power measurement is the compute-node subsystem. The compute-node subsystem is the set of compute nodes. Measure the greater of $ \frac{1}{64} $ of the compute-node subsystem or 1kW of power.
+For Level 1, the only subsystem that requires an actual power measurement is the compute-node subsystem. 
+The compute-node subsystem is the set of compute nodes. Measure the greater of $ \frac{1}{64} $ of the compute-node subsystem or 1kW of power.
 
-List any other subsystems that contribute to the workload, but do not provide estimated values for their contribution.
+ 
+The interconnect subsystem participating in the workload must be measured or, if not measured, the contribution 
+must be estimated. 
+
+List all other subsystems that contribute to the workload, but you do not have to provide 
+measured or estimated values for their contribution.
 
 For some systems, it may be impossible not to include a power contribution from some subsystems. In this case, list what you are including, but do not subtract an estimated value for the included subsystem.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -125,7 +125,8 @@ The compute-node subsystem is the set of compute nodes. Measure the greater of $
 
  
 The interconnect subsystem participating in the workload must be measured or, if not measured, the contribution 
-must be estimated. 
+must be estimated. The interconnect is everything that you need to operate the network that is not part of the compute subsystem. 
+This may include infrastructure that is shared, but excludes the part that is not servicing the current cluster.
 
 List all other subsystems that contribute to the workload, but you do not have to provide 
 measured or estimated values for their contribution.


### PR DESCRIPTION
Added a requirement that the interconnect subsystem participating in the workload must be measured or, if not measured, the contribution must be estimated.  Modified prior language that restricted requirement to compute subsystem.