### PR TITLE
L2 Typo for Fraction Req'd

### DIFF
--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -162,7 +162,7 @@ In the case of estimated measurements for subsystems other than
 the compute-node subsystem, the submission must include the relevant 
 manufacturer specifications and formulas used for power estimation. 
 
-Measure the greater of at least 10KW of power or $ \frac{1}{3} $ of the compute-node subsystem.
+Measure the greater of at least 10KW of power or $ \frac{1}{8} $ of the compute-node subsystem.
 
 \item
 For Level 3, all subsystems participating in the workload must be measured.


### PR DESCRIPTION
The L2 Fraction Req'd is shown as 1/3, should be 1/8.