### PR TITLE
ANSI Reference, not specification

### DIFF
--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -15,16 +15,19 @@ The section contains definitions of the terms used to describe the elements of a
 \label{sec:MDSpecs}
 \noindent
 Measuring devices must meet the Level requirements as defined in 
-Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}. This section lists resources for finding and evaluating meters.
+Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}. 
 \wl
-
+Measuring devices may be any revenue grade meter, and/or any meter on the list of accepted power measurement devices from the
+Standard Performance Evaluation Corporation, and/or
+any meter documented to have an accuracy of 5\% for Level 1, 2\% for Level 2 and 1\% for Level 1 measurements.
 \noindent
-The ANSI specification for revenue-grade meters is ANSI C12.20. This is a reference only, not a specification.
+
 \wl
 
 \noindent
 Also, refer to 
-the {\itshape Power and Temperature Measurement Setup Guide \/} and the list of accepted power measurement devices from the Standard Performance Evaluation Corporation.
+the {\itshape Power and Temperature Measurement Setup Guide \/} and the list of accepted power measurement devices from the 
+Standard Performance Evaluation Corporation.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -19,7 +19,7 @@ Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}. This section lists resources f
 \wl
 
 \noindent
-The ANSI specification for revenue-grade meters is ANSI C12.20. 
+The ANSI specification for revenue-grade meters is ANSI C12.20. This is a reference only, not a specification.
 \wl
 
 \noindent


### PR DESCRIPTION
Added a sentence clarifying that the ANSI specification is included as a reference only. It is not a specification.  That said, we may want to specify minimum requirements for meters.

fixes #8 