### PR TITLE
Environmental factors adapted for hybrid systems

### DIFF
--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -544,19 +544,23 @@ Submitters may find it useful to create such a schematic to identify the power m
 \section{Environmental Factors}
 \label{sec:EF}
 \noindent
-Reporting information about the cooling system temperature is required.  All Levels require both the in and the out temperature of the cooling system. For air-cooled systems, these are the in and out air temperatures. For liquid-cooled systems, these are the in and out temperatures of the liquid.
+Reporting information about the cooling system temperature is required.  
+All Levels require both the in and the out temperature of the cooling system. 
+A system can have a hybrid cooling system, having both liquid and air cooling mechanisms.  
+If it is a hybrd system, temperatures on both air and liquid must be reported as part of the submitted data.
+For air-cooled systems, these are the in and out air temperatures. 
+For liquid-cooled systems, these are the in and out temperatures of the liquid.
 \wl
 
 \noindent
-Even though large systems often have multiple levels of heat energy exchange, the cooling method here refers to how the CPU is cooled.  If the CPU has a heat sink and air blows over it, then it is air-cooled.  If the CPU is embedded in water or some other refrigerant, then it is liquid-cooled.
+For air-cooling, the air temperature both at the entrance to the computer system 
+and at the exhaust must be measured sometime during the core phase of the computational run.  
+These temperatures must be reported as part of the submitted data.
 \wl
 
 \noindent
-For air-cooled systems, the air temperature both at the entrance to the computer system and at the exhaust must be measured sometime during the core phase of the computational run.  These temperatures must be reported as part of the submitted data.
-\wl
-
-\noindent
-For liquid-cooled systems, the temperature of both the incoming and outgoing cooling liquid must be measured sometime during the core phase run, and that temperature must be reported in the submission.
+For liquid-cooling, the temperature of both the incoming and outgoing cooling liquid 
+must be measured sometime during the core phase run, and that temperature must be reported in the submission.
 \wl
 
 \noindent


### PR DESCRIPTION
The environmental factors are too restrictive written as either air or liquid cooled systems.  They now account for hybrid cooling systems.