### PR TITLE
change text such that the duration of the equally spaced measurements for l2 must covert exactly the core phase

### DIFF
--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -88,9 +88,9 @@ Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements f
 measurement and how it differs from a total energy measurement.
 
 For Level 2, the workload run must have a series of equally spaced power-averaged measurements of equal length, sampled at least once per second.
-These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the
-core phase of the workload. The reported average power for the core phase of the run is the numerical average of the
-10 (or more) power-averaged measurements collected during the core phase.
+These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
+The reported average power for the core phase of the run is the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.
+The intervals must be chosen such that the measurements used for this numerical average must cover exactly the core phase of the benchmark.
 
 Each of the required equally spaced measurements required for L2 must power-average over the entire separating space. 
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -72,7 +72,10 @@ For example, if power measurements may be taken once per second for one minute f
 \wl
 
 \noindent
-Level 2 also requires that power measurements be taken at least once per second. Level 2 requires that power values be reported for both the core phase of the workload and the total workload. The reported power value for the core phase must be the result of at least 10 power measurements. These 10 power measurements may themselves be power-averaged measurements.
+Level 2 also requires that power measurements be taken at least once per second.
+Level 2 requires that power values be reported for both the core phase of the workload and the total workload.
+The reported power value for the core phase must be the result of at least 10 power measurements, that cover exactly the duration of the core phase of the benchmark.
+These 10 power measurements may themselves be power-averaged measurements.
 \wl
 
 \noindent
@@ -293,7 +296,11 @@ Figure~\ref{fig:a1l1pm} illustrates Aspect 1 Level 1 power measurement. If, as r
 
 \subsection{Level 2}
 \noindent
-Level 2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run. The workload run must have a series of equally spaced power-averaged measurements of equal length. These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload. The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.  
+Level 2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run.
+The workload run must have a series of equally spaced power-averaged measurements of equal length.
+These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
+The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.
+The intervals must be chosen such that the measurements used for this numerical average must cover exactly the core phase of the benchmark.
 \wl
 
 \noindent


### PR DESCRIPTION
Fixes #65 