### PR TITLE
General Improvements and clarifications

### DIFF
--- a/methodology.tex
+++ b/methodology.tex
@@ -24,6 +24,9 @@
 }{\end{itemize}}
 
 
+\newcommand*{\numnameref}[1]{\ref{#1} \nameref{#1}}
+
+
 \def\wl{\par \vspace{\baselineskip}}
 
 \begin{document}

--- a/methodology.tex
+++ b/methodology.tex
@@ -25,7 +25,10 @@
 
 
 \newcommand*{\numnameref}[1]{\ref{#1} \nameref{#1}}
-
+% prevent bad page breaks
+\clubpenalty10000
+\widowpenalty10000
+\displaywidowpenalty=10000
 
 \def\wl{\par \vspace{\baselineskip}}
 

--- a/methodology.tex
+++ b/methodology.tex
@@ -51,6 +51,23 @@ Energy Efficient High Performance Computing Power Measurement Methodology \\
 \listoftables
 \listoffigures
 
+\newcommand{\SpecRateLThreeAC}{5~kHz}
+\newcommand{\SpecRateLThreeDC}{120~Hz}
+\newcommand{\SpecAccuracyLThree}{1\%}
+\newcommand{\SpecAccuracyLTwo}{2\%}
+\newcommand{\SpecAccuracyLOne}{5\%}
+\newcommand{\SpecAccuracyMeter}{3\%}
+\newcommand{\SpecPowerMinLOne}{2~kW}
+\newcommand{\SpecPowerMinLTwo}{10~kW}
+\newcommand{\SpecPowerMaxLOne}{40~kW}
+\newcommand{\SpecFracMinLOne}{$\frac{1}{10}$}
+\newcommand{\SpecFracMinLTwo}{$\frac{1}{8}$}
+\newcommand{\SpecMinNodes}{15}
+\newcommand{\MinMeasurementsCorePhaseLTwoThree}{10}
+\newcommand{\MaxReadingIntervalCorePhaseLTwoThree}{10\%}
+\newcommand{\MaxSecMissingLThree}{10}
+\newcommand{\MaxSecMissingLThreeHalf}{5} %must be half of the above value!
+
 %
 \input{text/intro}
 \input{text/checklist}

--- a/methodology.tex
+++ b/methodology.tex
@@ -40,7 +40,7 @@
 \title{
 Energy Efficient High Performance Computing Power Measurement Methodology \\
 \bigskip
-\normalsize{(version 2.0 comment draft 2)}
+\normalsize{(version 2.0 comment draft 3)}
 }
 
 

--- a/methodology.tex
+++ b/methodology.tex
@@ -5,6 +5,7 @@
 \usepackage{graphicx}
 \usepackage{url}
 \usepackage{amsmath}
+\usepackage{nameref}
 
 %
 

--- a/text/changenotices.tex
+++ b/text/changenotices.tex
@@ -2,13 +2,13 @@
 \label{sec:changenotices}
 
 \noindent
-A Change Management process establishes an orderly and effective procedure for tracking the submission, coordination, review, and approval for release of all changes to this document. 
+A Change Management process establishes an orderly and effective procedure for tracking the submission, coordination, review, and approval for release of all changes to this document.
 
 This document has been created in a github repository and the Change Management process leverages the features of github.
-This repository is public and anyone can access the document.  
+This repository is public and anyone can access the document.
 The repository is located at
 \url{https://github.com/EEHPCWG/PowerMeasurementMethodology}
-Anyone can submit issues against the document.  
+Anyone can submit issues against the document.
 Editing the document is restricted to specific individuals from The Green500 and the Energy Efficient High Performance Computing Working Group.
 Github provides full history tracking for the entire life of the document.
 A released version of the document will be posted on the Green500 website.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -72,9 +72,9 @@ Alternatively, it is allowed to measure either at least 40~kW or the whole machi
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
-This may include infrastructure that is shared, but excludes that part that is not servicing the current cluster.
+This may include infrastructure that is shared, but excludes parts that are not servicing the system under test.
 
-For some systems, it may be impossible not to include a power contribution from a certain subsystems that is not used for the benchmark run.
+For some systems, it may be impossible not to include a power contribution from certain subsystems that are not used for the benchmark run.
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
 If the compute-node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
@@ -104,7 +104,7 @@ Refer to Section~\ref{sec:FoRM} for more information about the format of reporte
 
 For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
 As for Level~1, estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
-Level~2 requires that the greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW of power or 15 compute nodes be measured.
+Level~2 requires that the largest of $\frac{1}{8}$ of the compute-node subsystem, or 10~kW of power, or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
 The compute-node subsystem is the set of compute nodes. As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
@@ -167,7 +167,7 @@ Measure the greater of at least 2~kW of power or $\frac{1}{10}$ of the compute-n
 For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
 The Measured~\% and the Derived~\% must sum to the Total~\%.
 
-Measure the greater of at least 10~kW of power or $\frac{1}{8}$ of the compute-node subsystem or 15 compute nodes.
+Measure the largest of at least 10~kW of power, or $\frac{1}{8}$ of the compute-node subsystem, or 15 compute nodes.
 
 \item
 For Level~3, all subsystems participating in the workload must be measured completely.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -77,8 +77,14 @@ This may include infrastructure that is shared, but excludes that part that is n
 For some systems, it may be impossible not to include a power contribution from a certain subsystems that is not used for the benchmark run.
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
+<<<<<<< 2df1b8d75a3270f3ff230fbd9371256dd1b3b9b6
 If the compute node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
 Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
+=======
+If the compute-node subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
+Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about
+ heterogeneous sets of compute nodes.
+>>>>>>> compute-node subsystem hyphenation
 
 \newpage
 \item[{[ ]}]

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -16,18 +16,20 @@ information when you run your workload.
 \textbf{Quality Level}
 \addcontentsline{toc}{subsection}{Quality Level}
 
-Choosing a quality level is the first important decision a submitter must make. Refer to 
-Section~\numnameref{sec:AQLevels} for general information about the three quality levels.  
+Choosing a quality level is the first important decision a submitter must make.
+Refer to Section~\numnameref{sec:AQLevels} for general information about the three quality levels.
 Sections~\ref{sec:A1GTRM} through \ref{sec:A4wEMaT} describe the details of the three quality levels
 
 \item[{[ ]}]
 \textbf{Power Measurement Locations}
 \addcontentsline{toc}{subsection}{Power Measurement Locations}
 
-Measurements of power or energy are often made at multiple locations in parallel across the computer system. A typical location might be the output of the building transformer.
+Measurements of power or energy are often made at multiple locations in parallel across the computer system.
+A typical location might be the output of the building transformer.
 Refer to Section~\numnameref{sec:A4wEMaT} for more information about power measurement locations.
 
-Note that in some cases, you may have to adjust for power loss. For information about power loss, refer to Section~\numnameref{sec:AfPL}.
+Note that in some cases, you may have to adjust for power loss.
+For information about power loss, refer to Section~\numnameref{sec:AfPL}.
 If you adjust for power loss, how you determined the power losses must be part of the submission.
 
 
@@ -37,19 +39,24 @@ If you adjust for power loss, how you determined the power losses must be part o
 \textbf{Measuring Devices}
 \addcontentsline{toc}{subsection}{Measuring Devices}
 
-Specify the measuring device or devices used. A reference to the device specifications is useful.
+Specify the measuring device or devices used.
+A reference to the device specifications is useful.
 
-Refer to Section~\ref{sec:MDTerm} for some terminology about the measuring device specific to the power submissions described in this document. This section describes the difference between power-averaged measurements and total energy measurements.
+Refer to Section~\ref{sec:MDTerm} for some terminology about the measuring device specific to the power submissions described in this document.
+This section describes the difference between power-averaged measurements and total energy measurements.
 
 Refer to Section~\ref{sec:MDSpecs} for information about the required measuring device.
 
-If multiple meters are used, describe how the data aggregation and synchronization were performed. One possibility is to have the nodes NTP-synchronized; the power meter's controller is then also NTP-synchronized prior to the run.
+If multiple meters are used, describe how the data aggregation and synchronization were performed.
+One possibility is to have the nodes NTP-synchronized; the power meter's controller is then also NTP-synchronized prior to the run.
 
 \item[{[ ]}]
 \textbf{Workload Requirement}
 \addcontentsline{toc}{subsection}{Workload Requirement}
 
-The workload must run on all compute nodes of the system. Level~3 measures the power for the entire system. Levels 1 and 2 measure the power for a portion of the system and extrapolate a value for the entire system. 
+The workload must run on all compute nodes of the system.
+Level~3 measures the power for the entire system.
+Levels~1 and~2 measure the power for a portion of the system and extrapolate a value for the entire system.
 
 \item[{[ ]}]
 \textbf{Level~1 Power Measurement Summary}
@@ -64,21 +71,22 @@ The core phase is required to run for at least one minute.
 
 Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~1 power submission.
 
-For Level~1, both the compute-node subsystem and the interconnect must be reported.  
-The compute-node subsystem power must be measured. 
+For Level~1, both the compute-node subsystem and the interconnect must be reported.
+The compute-node subsystem power must be measured.
 For the compute subsystem measure a minimum of 2~kW of power, 10\% of the system, or 15 nodes whichever is largest.
 Alternatively, it is allowed to measure either at least 40~kW or the whole machine.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
-Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
+Include everything that you need to operate the interconnect network that is not part of the compute subsystem.
 This may include infrastructure that is shared, but excludes parts that are not servicing the system under test.
 
 For some systems, it may be impossible not to include a power contribution from certain subsystems that are not used for the benchmark run.
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
-If the compute-node-subsystem contains different types of compute nodes, measure at least 10\% of each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
-Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
+If the compute-node-subsystem contains different types of compute nodes, measure at least 10\% of each of the heterogeneous sets.
+The contribution from compute nodes not measured must be extrapolated.
+Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage
 \item[{[ ]}]
@@ -96,9 +104,9 @@ The core phase is required to run for at least one minute.
 On top of these full measurements, Level~2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
 For this purpose, a series of equally spaced power-averaged measurements of equal length must be submitted.
 These power-averaged measurements must be taken often enough so that at least 10 measurements are reported during the core phase of the workload.
-Each of these required equally spaced measurements required for Level~2 must be a power-averaged measurement over the entire separating space. 
+Each of these required equally spaced measurements required for Level~2 must be a power-averaged measurement over the entire separating space.
 
-Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~2 Power Submission. 
+Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~2 Power Submission.
 
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
@@ -107,7 +115,9 @@ As for Level~1, estimation is performed by substituting the measurement by an up
 Level~2 requires that the largest of $\frac{1}{8}$ of the compute-node subsystem, or 10~kW of power, or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
-The compute-node subsystem is the set of compute nodes. As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least \frac{1}{8} from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated.
+The compute-node subsystem is the set of compute nodes.
+As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least $\frac{1}{8}$ from each of the heterogeneous sets.
+The contribution from compute nodes not measured must be extrapolated.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage
@@ -130,8 +140,8 @@ Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~3 
 
 Refer to Section~\numnameref{sec:FoRM} for more information about the format of reported measurements.
 
-For Level~3, all subsystems participating in the workload must be measured. Refer to 
-Section~\numnameref{sec:A3SIiIP} for more information about included subsystems.
+For Level~3, all subsystems participating in the workload must be measured.
+Refer to Section~\numnameref{sec:A3SIiIP} for more information about included subsystems.
 
 With Level~3, the submitter need not be concerned about different types of compute nodes because Level~3 measures the entire system.
 
@@ -140,23 +150,28 @@ With Level~3, the submitter need not be concerned about different types of compu
 \textbf{Idle Power}
 \addcontentsline{toc}{subsection}{Idle Power}
 
-Idle power is defined as the power used by the system when it is not running a workload, but it is in a state where it is ready to accept a workload. The idle state is not a sleep or a hibernation state.
+Idle power is defined as the power used by the system when it is not running a workload, but it is in a state where it is ready to accept a workload.
+The idle state is not a sleep or a hibernation state.
 
-An idle measurement need not be linked to a particular workload. The idle measurement need not be made just before or after the workload is run. Think of the idle power measurement as a constant of the system. Think of idle power as a baseline power consumption when no workload is running. 
+An idle measurement need not be linked to a particular workload.
+The idle measurement need not be made just before or after the workload is run.
+Think of the idle power measurement as a constant of the system.
+Think of idle power as a baseline power consumption when no workload is running.
 
-For Levels 2 and 3, there must be at least one idle measurement. An idle measurement is optional for Level~1. 
+For Levels 2 and 3, there must be at least one idle measurement.
+An idle measurement is optional for Level~1.
 
 \newpage
 \item[{[ ]}]
 \textbf{Included Subsystems}
 \addcontentsline{toc}{subsection}{Included Subsystems}
 
-Subsystems include (but are not limited to) computational nodes, any interconnect network the application uses, any head or control nodes, any storage system the application uses, and any internal cooling devices (self-contained liquid cooling systems and fans).  
+Subsystems include (but are not limited to) computational nodes, any interconnect network the application uses, any head or control nodes, any storage system the application uses, and any internal cooling devices (self-contained liquid cooling systems and fans).
 
 \begin{itemize}
 \item
-For Level~1, both the compute-node subsystem and the interconnect must be reported.  
-The compute-node subsystem power must be measured. 
+For Level~1, both the compute-node subsystem and the interconnect must be reported.
+The compute-node subsystem power must be measured.
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 
 Measure the greater of at least 2~kW of power or $\frac{1}{10}$ of the compute-node subsystem or 15 compute nodes.
@@ -172,7 +187,7 @@ For Level~3, all subsystems participating in the workload must be measured compl
 \end{itemize}
 
 Estimation must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
-The submission must include the relevant manufacturer specifications and formulas used for power estimation. 
+The submission must include the relevant manufacturer specifications and formulas used for power estimation.
 
 Include additional subsystems if needed.
 
@@ -185,7 +200,8 @@ Refer to Section~\numnameref{sec:A2MFI} for information about \% requirements fo
 \addcontentsline{toc}{subsection}{Tunable Parameters}
 
 Listing tunable parameters for all levels is optional.
-Typical tunable values are the CPU frequency, memory settings, and internal network settings. Be conservative, but list any other values you consider important.
+Typical tunable values are the CPU frequency, memory settings, and internal network settings.
+Be conservative, but list any other values you consider important.
 
 A tunable parameter is one that has a default value that you can easily change before running the workload.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -73,8 +73,8 @@ Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~1 
 
 For Level~1, both the compute-node subsystem and the interconnect must be reported.
 The compute-node subsystem power must be measured.
-For the compute subsystem measure a minimum of 2~kW of power, 10\% of the system, or 15 nodes whichever is largest.
-Alternatively, it is allowed to measure either at least 40~kW or the whole machine.
+For the compute subsystem measure a minimum of \SpecPowerMinLOne{} of power, \SpecFracMinLOne{} of the system, or \SpecMinNodes{} nodes whichever is largest.
+Alternatively, it is allowed to measure either at least \SpecPowerMaxLOne{} or the whole machine.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Estimation is performed by substituting the measurement by an upper bound derived from the maximum specified power consumption of all hardware components.
@@ -84,7 +84,7 @@ This may include infrastructure that is shared, but excludes parts that are not 
 For some systems, it may be impossible not to include a power contribution from certain subsystems that are not used for the benchmark run.
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
-If the compute-node-subsystem contains different types of compute nodes, measure at least 10\% of each of the heterogeneous sets.
+If the compute-node-subsystem contains different types of compute nodes, measure at least \SpecFracMinLOne{} of each of the heterogeneous sets.
 These measurements are then extrapolated to the full system.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
@@ -103,7 +103,7 @@ The core phase is required to run for at least one minute.
 
 On top of these full measurements, Level~2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
 For this purpose, a series of power-averaged measurements of equal length at regular intervals must be submitted for the full run.
-These intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload.
+These intervals must be short enough so that at least \MinMeasurementsCorePhaseLTwoThree{} measurements are reported during the core phase of the workload.
 There must be no gap between these regular measurements, i.e. this series of measurements in total must cover the full run.
 
 Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~2 Power Submission.
@@ -112,12 +112,12 @@ Refer to Section~\ref{sec:FoRM} for more information about the format of reporte
 
 For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
 As for Level~1, estimation is performed by substituting the measurement by an upper bound derived from the maximum specified power consumption of all hardware components.
-Level~2 requires that the largest of $\frac{1}{8}$ of the compute-node subsystem, or 10~kW of power, or 15 compute nodes be measured.
-It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
+Level~2 requires that the largest of \SpecFracMinLTwo{} of the compute-node subsystem, or \SpecPowerMinLTwo{} of power, or \SpecMinNodes{} compute nodes be measured.
+It is acceptable to exceed this requirement or to measure the whole machine if smaller than \SpecMinNodes{} nodes.
 
 The compute-node subsystem is the set of compute nodes.
 As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure a fraction of each heterogeneous set.
-For Level~2, this fraction must be at least $\frac{1}{8}$ of each set.
+For Level~2, this fraction must be at least \SpecFracMinLTwo{} of each set.
 These measurements are then extrapolated to the full system.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
@@ -135,7 +135,7 @@ These last and first measurements in the core phase must be timed such that no m
 
 Refer to Section~\numnameref{sec:PAaTEM} for information about the distinction between energy and power.
 
-The complete set of total energy readings used to calculate average power (at least 10 during the core computation phase) must be included in the submission, along with the execution time for the core phase and the execution time for the full run.
+The complete set of total energy readings used to calculate average power (at least \MinMeasurementsCorePhaseLTwoThree{} during the core computation phase) must be included in the submission, along with the execution time for the core phase and the execution time for the full run.
 
 Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~3 Power Submission.
 
@@ -175,12 +175,12 @@ For Level~1, both the compute-node subsystem and the interconnect must be report
 The compute-node subsystem power must be measured.
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 
-Measure the greater of at least 2~kW of power or $\frac{1}{10}$ of the compute-node subsystem or 15 compute nodes.
+Measure the greater of at least \SpecPowerMinLOne{} of power or \SpecFracMinLOne{} of the compute-node subsystem or \SpecMinNodes{} compute nodes.
 
 \item
 For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
 
-Measure the largest of at least 10~kW of power, or $\frac{1}{8}$ of the compute-node subsystem, or 15 compute nodes.
+Measure the largest of at least \SpecPowerMinLTwo{} of power, or \SpecFracMinLTwo{} of the compute-node subsystem, or \SpecMinNodes{} compute nodes.
 
 \item
 For Level~3, all subsystems participating in the workload must be measured completely.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -164,19 +164,18 @@ For Level 1, both the compute-node subsystem and the interconnect must be report
 The compute-node subsystem power must be measured. 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 
-
 \item
 For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
 The Measured \% and the Derived \% must sum to the Total \%.
-
-Estimation must be performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
-The submission must include the relevant manufacturer specifications and formulas used for power estimation. 
 
 Measure the greater of at least 10KW of power or $ \frac{1}{8} $ of the compute-node subsystem or 15 compute nodes.
 
 \item
 For Level 3, all subsystems participating in the workload must be measured.
 \end{itemize}
+
+Estimation must be performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
+The submission must include the relevant manufacturer specifications and formulas used for power estimation. 
 
 Include additional subsystems if needed.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -122,9 +122,9 @@ The core phase is usually considered to be the section of the workload that unde
 The core phase is required to run for at least one minute.
 
 Level 3 measures energy.
-Power is calculated by dividing the measured energy by the elapsed time.
 The measured energy is the last measured total energy within the core phase minus the first measured total energy within the core phase.
-These last and first measurements in the core phase must be timed such that no more than a total of two seconds (one each at begin and end) of the core phase are not covered by the total energy measurement.
+The final power is calculated by dividing this energy by the elapsed time between these first and last energy readings.
+These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 
 Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for information about the distinction between energy and power.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -158,7 +158,7 @@ The idle measurement need not be made just before or after the workload is run.
 Think of the idle power measurement as a constant of the system.
 Think of idle power as a baseline power consumption when no workload is running.
 
-For Levels 2 and 3, there must be at least one idle measurement.
+For Levels~2 and~3, there must be at least one idle measurement.
 An idle measurement is optional for Level~1.
 
 \newpage
@@ -193,7 +193,7 @@ Include additional subsystems if needed.
 
 Refer to Section~\numnameref{sec:A3SIiIP} for more information about included subsystems.
 
-Refer to Section~\numnameref{sec:A2MFI} for information about \% requirements for Levels 1 and 2.
+Refer to Section~\numnameref{sec:A2MFI} for information about \% requirements for Levels~1 and~2.
  
 \item[{[ ]}]
 \textbf{Tunable Parameters}

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -77,7 +77,7 @@ This may include infrastructure that is shared, but excludes parts that are not 
 For some systems, it may be impossible not to include a power contribution from certain subsystems that are not used for the benchmark run.
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
-If the compute-node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
+If the compute-node-subsystem contains different types of compute nodes, measure at least 10\% of each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
 Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage
@@ -107,7 +107,7 @@ As for Level~1, estimation is performed by substituting the measurement by an up
 Level~2 requires that the largest of $\frac{1}{8}$ of the compute-node subsystem, or 10~kW of power, or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
-The compute-node subsystem is the set of compute nodes. As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated.
+The compute-node subsystem is the set of compute nodes. As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least \frac{1}{8} from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -58,8 +58,8 @@ The workload must run on all compute nodes of the system. Level 3 measures the p
 
 Level 1 submissions include the average power over the entire core phase of the run (see \ref{sec:core_phase} for definition of core phase).
 
-For Level 1, the power during the entire core phase must be sampled at least once per second.
-The submitted value must be the average of all power samples taken during the core phase of the run.
+For Level 1, the power during the entire core phase must be measured.
+The submitted value must be the average of all power readings taken during the core phase of the run.
 Refer to Section~\ref{sec:PAaTEM} for information on power averaged measurements.
 The core phase is required to run for at least one minute.
 
@@ -67,9 +67,9 @@ Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported M
 
 For Level 1, both the compute-node subsystem and the interconnect must be reported.  
 The compute-node subsystem power must be measured. 
-For the compute subsystem measure a minimum of 2kw of power, 
+For the compute subsystem measure a minimum of 2kW of power, 
 10\% of the system, or 15 nodes whichever is largest.
-It is allowed to measure either at least 40kw or the whole machine if smaller than the largest requirement.
+It is allowed to measure either at least 40kW or the whole machine if smaller than the largest requirement.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Estimation is performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
@@ -89,16 +89,16 @@ Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power fo
 
 Level 2 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).
 
-For level 2, the power during the full run must be sampled at least once per second.
-As with Level 1, the submitted value for the core phase must be the average of all power samples taken during the core phase of the run.
-In addition, the average of all power samples during the full run must be submitted.
+For level 2, the power during the core phase and during the full run must be measured.
+As with Level 1, the submitted value for the core phase must be the average of all power readings taken during the core phase of the run.
+In addition, the average of all power readings during the full run must be submitted.
 Refer to Section~\ref{sec:PAaTEM} for information on power averaged measurements.
 The core phase is required to run for at least one minute.
 
 On top of these full measurements, Level 2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
 For this purpose, a series of equally spaced power-averaged measurements of equal length must be submitted.
 These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
-Each of the required equally spaced measurements required for Level 2 must be power-averaged measurements over the entire separating space. 
+Each of the required equally spaced measurements required for Level 2 must be a power-averaged measurement over the entire separating space. 
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 2 Power Submission. 
 
@@ -168,7 +168,7 @@ The interconnect subsystem participating in the workload must also be measured o
 For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
 The Measured \% and the Derived \% must sum to the Total \%.
 
-Measure the greater of at least 10KW of power or $ \frac{1}{8} $ of the compute-node subsystem or 15 compute nodes.
+Measure the greater of at least 10kW of power or $ \frac{1}{8} $ of the compute-node subsystem or 15 compute nodes.
 
 \item
 For Level 3, all subsystems participating in the workload must be measured.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -49,22 +49,22 @@ If multiple meters are used, describe how the data aggregation and synchronizati
 \textbf{Workload Requirement}
 \addcontentsline{toc}{subsection}{Workload Requirement}
 
-The workload must run on all compute nodes of the system. Level 3 measures the power for the entire system. Levels 1 and 2 measure the power for a portion of the system and extrapolate a value for the entire system. 
+The workload must run on all compute nodes of the system. Level~3 measures the power for the entire system. Levels 1 and 2 measure the power for a portion of the system and extrapolate a value for the entire system. 
 
 \item[{[ ]}]
-\textbf{Level 1 Power Measurement}
-\addcontentsline{toc}{subsection}{Level 1 Power Measurement}
+\textbf{Level~1 Power Measurement}
+\addcontentsline{toc}{subsection}{Level~1 Power Measurement}
 
-Level 1 submissions include the average power over the entire core phase of the run (see \ref{sec:core_phase} for definition of core phase).
+Level~1 submissions include the average power over the entire core phase of the run (see \ref{sec:core_phase} for definition of core phase).
 
-For Level 1, the power during the entire core phase must be measured.
+For Level~1, the power during the entire core phase must be measured.
 The submitted value must be the average of all power readings taken during the core phase of the run.
 Refer to Section~\ref{sec:PAaTEM} for information on power averaged measurements.
 The core phase is required to run for at least one minute.
 
-Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 1 power submission.
+Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level~1 power submission.
 
-For Level 1, both the compute-node subsystem and the interconnect must be reported.  
+For Level~1, both the compute-node subsystem and the interconnect must be reported.  
 The compute-node subsystem power must be measured. 
 For the compute subsystem measure a minimum of 2~kW of power, 10\% of the system, or 15 nodes whichever is largest.
 Alternatively, it is allowed to measure either at least 40~kW or the whole machine.
@@ -82,44 +82,44 @@ Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power fo
 
 \newpage
 \item[{[ ]}]
-\textbf{Level 2 Power Measurement}
-\addcontentsline{toc}{subsection}{Level 2 Power Measurement}
+\textbf{Level~2 Power Measurement}
+\addcontentsline{toc}{subsection}{Level~2 Power Measurement}
 
-Level 2 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).
+Level~2 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).
 
-For level 2, the power during the core phase and during the full run must be measured.
-As with Level 1, the submitted value for the core phase must be the average of all power readings taken during the core phase of the run.
+For level~2, the power during the core phase and during the full run must be measured.
+As with Level~1, the submitted value for the core phase must be the average of all power readings taken during the core phase of the run.
 In addition, the average of all power readings during the full run must be submitted.
 Refer to Section~\ref{sec:PAaTEM} for information on power averaged measurements.
 The core phase is required to run for at least one minute.
 
-On top of these full measurements, Level 2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
+On top of these full measurements, Level~2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
 For this purpose, a series of equally spaced power-averaged measurements of equal length must be submitted.
 These power-averaged measurements must be taken often enough so that at least 10 measurements are reported during the core phase of the workload.
-Each of these required equally spaced measurements required for Level 2 must be a power-averaged measurement over the entire separating space. 
+Each of these required equally spaced measurements required for Level~2 must be a power-averaged measurement over the entire separating space. 
 
-Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 2 Power Submission. 
+Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level~2 Power Submission. 
 
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
-For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
-As for level 1, estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
-Level 2 requires that the greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW of power or 15 compute nodes be measured.
+For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
+As for Level~1, estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
+Level~2 requires that the greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW of power or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
-The compute-node subsystem is the set of compute nodes. As with Level 1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
+The compute-node subsystem is the set of compute nodes. As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
 
 \newpage
 \item[{[ ]}]
-\textbf{Level 3 Power Measurement}
-\addcontentsline{toc}{subsection}{Level 3 Power Measurement}
+\textbf{Level~3 Power Measurement}
+\addcontentsline{toc}{subsection}{Level~3 Power Measurement}
 
-Level 3 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).
+Level~3 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).
 
 The core phase is usually considered to be the section of the workload that undergoes parallel execution. The core phase typically does not include the parallel job launch and teardown.
 The core phase is required to run for at least one minute.
 
-Level 3 measures energy.
+Level~3 measures energy.
 The measured energy is the last measured total energy within the core phase minus the first measured total energy within the core phase.
 The final power is calculated by dividing this energy by the elapsed time between these first and last energy readings.
 These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
@@ -129,14 +129,14 @@ Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements f
 The complete set of total energy readings used to calculate average power (at least 10 during the core computation phase) must be included, along with the execution time for the core phase and the execution time for the full run.
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more 
-information about the Level 3 Power Submission.
+information about the Level~3 Power Submission.
 
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
-For Level 3, all subsystems participating in the workload must be measured. Refer to 
+For Level~3, all subsystems participating in the workload must be measured. Refer to 
 Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for more information about included subsystems.
 
-With Level 3, the submitter need not be concerned about different types of compute nodes because Level 3 measures the entire system.
+With Level~3, the submitter need not be concerned about different types of compute nodes because Level~3 measures the entire system.
 
 
 \item[{[ ]}]
@@ -147,7 +147,7 @@ Idle power is defined as the power used by the system when it is not running a w
 
 An idle measurement need not be linked to a particular workload. The idle measurement need not be made just before or after the workload is run. Think of the idle power measurement as a constant of the system. Think of idle power as a baseline power consumption when no workload is running. 
 
-For Levels 2 and 3, there must be at least one idle measurement. An idle measurement is optional for Level 1. 
+For Levels 2 and 3, there must be at least one idle measurement. An idle measurement is optional for Level~1. 
 
 \newpage
 \item[{[ ]}]
@@ -158,20 +158,20 @@ Subsystems include (but are not limited to) computational nodes, any interconnec
 
 \begin{itemize}
 \item
-For Level 1, both the compute-node subsystem and the interconnect must be reported.  
+For Level~1, both the compute-node subsystem and the interconnect must be reported.  
 The compute-node subsystem power must be measured. 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 
 Measure the greater of at least 2~kW of power or $\frac{1}{10}$ of the compute-node subsystem or 15 compute nodes.
 
 \item
-For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
+For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
 The Measured~\% and the Derived~\% must sum to the Total~\%.
 
 Measure the greater of at least 10~kW of power or $\frac{1}{8}$ of the compute-node subsystem or 15 compute nodes.
 
 \item
-For Level 3, all subsystems participating in the workload must be measured completely.
+For Level~3, all subsystems participating in the workload must be measured completely.
 \end{itemize}
 
 Estimation must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -77,7 +77,7 @@ For the compute subsystem measure a minimum of 2~kW of power, 10\% of the system
 Alternatively, it is allowed to measure either at least 40~kW or the whole machine.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
-Estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
+Estimation is performed by substituting the measurement by an upper bound derived from the maximum specified power consumption of all hardware components.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem.
 This may include infrastructure that is shared, but excludes parts that are not servicing the system under test.
 
@@ -85,7 +85,7 @@ For some systems, it may be impossible not to include a power contribution from 
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
 If the compute-node-subsystem contains different types of compute nodes, measure at least 10\% of each of the heterogeneous sets.
-The contribution from compute nodes not measured must be extrapolated.
+These measurements are then extrapolated to the full system.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage
@@ -102,22 +102,23 @@ Refer to Section~\ref{sec:PAaTEM} for information on power averaged measurements
 The core phase is required to run for at least one minute.
 
 On top of these full measurements, Level~2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
-For this purpose, a series of equally spaced power-averaged measurements of equal length must be submitted.
-These power-averaged measurements must be taken often enough so that at least 10 measurements are reported during the core phase of the workload.
-Each of these required equally spaced measurements required for Level~2 must be a power-averaged measurement over the entire separating space.
+For this purpose, a series of power-averaged measurements of equal length at regular intervals must be submitted for the full run.
+These intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload.
+There must be no gap between these regular measurements, i.e. this series of measurements in total must cover the full run.
 
 Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~2 Power Submission.
 
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
 For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
-As for Level~1, estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
+As for Level~1, estimation is performed by substituting the measurement by an upper bound derived from the maximum specified power consumption of all hardware components.
 Level~2 requires that the largest of $\frac{1}{8}$ of the compute-node subsystem, or 10~kW of power, or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
 The compute-node subsystem is the set of compute nodes.
-As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least $\frac{1}{8}$ from each of the heterogeneous sets.
-The contribution from compute nodes not measured must be extrapolated.
+As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure a fraction of each heterogeneous set.
+For Level~2, this fraction must be at least $\frac{1}{8}$ of each set.
+These measurements are then extrapolated to the full system.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage
@@ -134,7 +135,7 @@ These last and first measurements in the core phase must be timed such that no m
 
 Refer to Section~\numnameref{sec:PAaTEM} for information about the distinction between energy and power.
 
-The complete set of total energy readings used to calculate average power (at least 10 during the core computation phase) must be included, along with the execution time for the core phase and the execution time for the full run.
+The complete set of total energy readings used to calculate average power (at least 10 during the core computation phase) must be included in the submission, along with the execution time for the core phase and the execution time for the full run.
 
 Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~3 Power Submission.
 
@@ -178,7 +179,6 @@ Measure the greater of at least 2~kW of power or $\frac{1}{10}$ of the compute-n
 
 \item
 For Level~2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
-The Measured~\% and the Derived~\% must sum to the Total~\%.
 
 Measure the largest of at least 10~kW of power, or $\frac{1}{8}$ of the compute-node subsystem, or 15 compute nodes.
 
@@ -186,14 +186,14 @@ Measure the largest of at least 10~kW of power, or $\frac{1}{8}$ of the compute-
 For Level~3, all subsystems participating in the workload must be measured completely.
 \end{itemize}
 
-Estimation must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
+Estimation must be performed by substituting the measurement by an upper bound derived from the maximum specified power consumption of all hardware components.
 The submission must include the relevant manufacturer specifications and formulas used for power estimation.
 
 Include additional subsystems if needed.
 
 Refer to Section~\numnameref{sec:A3SIiIP} for more information about included subsystems.
 
-Refer to Section~\numnameref{sec:A2MFI} for information about \% requirements for Levels~1 and~2.
+Refer to Section~\numnameref{sec:A2MFI} for information about measuring a subset of the compute-subsystem and extrapolating.
  
 \item[{[ ]}]
 \textbf{Tunable Parameters}

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -33,8 +33,6 @@ For information about power loss, refer to Section~\numnameref{sec:AfPL}.
 If you adjust for power loss, how you determined the power losses must be part of the submission.
 
 
-\newpage
-
 \item[{[ ]}]
 \textbf{Measuring Devices}
 \addcontentsline{toc}{subsection}{Measuring Devices}
@@ -88,7 +86,6 @@ If the compute-node-subsystem contains different types of compute nodes, measure
 These measurements are then extrapolated to the full system.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
-\newpage
 \item[{[ ]}]
 \textbf{Level~2 Power Measurement Summary}
 \addcontentsline{toc}{subsection}{Level~2 Power Measurement}
@@ -121,7 +118,6 @@ For Level~2, this fraction must be at least \SpecFracMinLTwo{} of each set.
 These measurements are then extrapolated to the full system.
 Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
-\newpage
 \item[{[ ]}]
 \textbf{Level~3 Power Measurement Summary}
 \addcontentsline{toc}{subsection}{Level~3 Power Measurement}
@@ -162,7 +158,6 @@ Think of idle power as a baseline power consumption when no workload is running.
 For Levels~2 and~3, there must be at least one idle measurement.
 An idle measurement is optional for Level~1.
 
-\newpage
 \item[{[ ]}]
 \textbf{Included Subsystems}
 \addcontentsline{toc}{subsection}{Included Subsystems}
@@ -207,7 +202,6 @@ A tunable parameter is one that has a default value that you can easily change b
 
 If you report tunable parameters, submit both the default value (the value that the data center normally supplies) and the value to which it has been changed.
 
-\newpage
 \item[{[ ]}]
 \textbf{Environmental Factors}
 \addcontentsline{toc}{subsection}{Environmental Factors}

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -116,9 +116,6 @@ The compute-node subsystem is the set of compute nodes. As with Level~1, if the 
 
 Level~3 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).
 
-The core phase is usually considered to be the section of the workload that undergoes parallel execution. The core phase typically does not include the parallel job launch and teardown.
-The core phase is required to run for at least one minute.
-
 Level~3 measures energy.
 The measured energy is the last measured total energy within the core phase minus the first measured total energy within the core phase.
 The final power is calculated by dividing this energy by the elapsed time between these first and last energy readings.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -118,7 +118,10 @@ Level 3 submissions include the average power during the core phase of the run a
 The core phase is usually considered to be the section of the workload that undergoes parallel execution. The core phase typically does not include the parallel job launch and teardown.
 The core phase is required to run for at least one minute.
 
-Level 3 measures energy. Power is calculated by dividing the measured energy by the elapsed time . The measured energy is the last measured total energy within the core phase minus the first measured total energy within the core phase.
+Level 3 measures energy.
+Power is calculated by dividing the measured energy by the elapsed time.
+The measured energy is the last measured total energy within the core phase minus the first measured total energy within the core phase.
+These last and first measurements in the core phase must be timed such that no more than a total of two seconds (one each at begin and end) of the core phase are not covered by the total energy measurement.
 
 Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for information about the distinction between energy and power.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -72,7 +72,7 @@ For the compute subsystem measure a minimum of 2kW of power,
 It is allowed to measure either at least 40kW or the whole machine if smaller than the largest requirement.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
-Estimation is performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
+Estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
 This may include infrastructure that is shared, but excludes that part that is not servicing the current cluster.
 
@@ -105,7 +105,7 @@ Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported M
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
 For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
-As for level 1, estimation is performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
+As for level 1, estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
 Level 2 requires that the greater of $ \frac{1}{8} $ of the compute-node subsystem or 10 kW of power or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
@@ -174,7 +174,7 @@ Measure the greater of at least 10kW of power or $ \frac{1}{8} $ of the compute-
 For Level 3, all subsystems participating in the workload must be measured.
 \end{itemize}
 
-Estimation must be performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
+Estimation must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
 The submission must include the relevant manufacturer specifications and formulas used for power estimation. 
 
 Include additional subsystems if needed.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -23,8 +23,8 @@ Sections~\ref{sec:A1GTRM} through \ref{sec:A4wEMaT} describe the details of the 
 \textbf{Power Measurement Locations}
 \addcontentsline{toc}{subsection}{Power Measurement Locations}
 
-Measurements of power or energy are often made at multiple points in parallel across the computer system. A typical location might be the output of the building transformer.
-Refer to Section~\ref{sec:A4wEMaT} Aspect 4: Point where the Electrical Measurements are Taken 
+Measurements of power or energy are often made at multiple locations in parallel across the computer system. A typical location might be the output of the building transformer.
+Refer to Section~\ref{sec:A4wEMaT}, \nameref{sec:A4wEMaT}
 for more information about power measurement locations.
 
 Note that in some cases, you may have to adjust for power loss. For information about power loss, refer to 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -52,7 +52,7 @@ If multiple meters are used, describe how the data aggregation and synchronizati
 The workload must run on all compute nodes of the system. Level~3 measures the power for the entire system. Levels 1 and 2 measure the power for a portion of the system and extrapolate a value for the entire system. 
 
 \item[{[ ]}]
-\textbf{Level~1 Power Measurement}
+\textbf{Level~1 Power Measurement Summary}
 \addcontentsline{toc}{subsection}{Level~1 Power Measurement}
 
 Level~1 submissions include the average power over the entire core phase of the run (see \ref{sec:core_phase} for definition of core phase).
@@ -82,7 +82,7 @@ Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of com
 
 \newpage
 \item[{[ ]}]
-\textbf{Level~2 Power Measurement}
+\textbf{Level~2 Power Measurement Summary}
 \addcontentsline{toc}{subsection}{Level~2 Power Measurement}
 
 Level~2 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).
@@ -112,7 +112,7 @@ Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous se
 
 \newpage
 \item[{[ ]}]
-\textbf{Level~3 Power Measurement}
+\textbf{Level~3 Power Measurement Summary}
 \addcontentsline{toc}{subsection}{Level~3 Power Measurement}
 
 Level~3 submissions include the average power during the core phase of the run and the average power during the full run (see \ref{sec:core_phase} for definition of core phase).

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -1,6 +1,5 @@
 \label{sec:checklist}
 
-
 \noindent
 This section contains a checklist with an overview of all the items of information you need to consider when making a power measurement.
 Afterward, Section~\ref{sec:reporting} provides a detailed and more elaborate description of all these items.
@@ -75,7 +74,7 @@ Estimation is performed by substituting the measurement by an uppower bound deri
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
 This may include infrastructure that is shared, but excludes that part that is not servicing the current cluster.
 
-For some systems, it may be impossible not to include a power contribution from some subsystems that are not used for the benchmark run.
+For some systems, it may be impossible not to include a power contribution from a certain subsystems that is not used for the benchmark run.
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
 If the compute node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
@@ -97,8 +96,7 @@ The core phase is required to run for at least one minute.
 On top of these full measurements, Level 2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
 For this purpose, a series of equally spaced power-averaged measurements of equal length must be submitted.
 These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
-Each of the required equally spaced measurements required for Level 2 must be a power-averaged measurement over the entire separating space. 
-
+Each of these required equally spaced measurements required for Level 2 must be a power-averaged measurement over the entire separating space. 
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 2 Power Submission. 
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -166,11 +166,11 @@ The interconnect subsystem participating in the workload must also be measured o
 
 
 \item
-For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated. The Measured \% and the Derived \% must sum to the Total \%.
+For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
+The Measured \% and the Derived \% must sum to the Total \%.
 
-In the case of estimated measurements for subsystems other than 
-the compute-node subsystem, the submission must include the relevant 
-manufacturer specifications and formulas used for power estimation. 
+Estimation must be performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
+The submission must include the relevant manufacturer specifications and formulas used for power estimation. 
 
 Measure the greater of at least 10KW of power or $ \frac{1}{8} $ of the compute-node subsystem or 15 compute nodes.
 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -107,7 +107,8 @@ As for Level~1, estimation is performed by substituting the measurement by an up
 Level~2 requires that the largest of $\frac{1}{8}$ of the compute-node subsystem, or 10~kW of power, or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
-The compute-node subsystem is the set of compute nodes. As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
+The compute-node subsystem is the set of compute nodes. As with Level~1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated.
+Refer to Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage
 \item[{[ ]}]

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -95,7 +95,7 @@ The core phase is required to run for at least one minute.
 
 On top of these full measurements, Level 2 also requires a set of intermediate measurements in order to see how the power consumption varies over time.
 For this purpose, a series of equally spaced power-averaged measurements of equal length must be submitted.
-These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
+These power-averaged measurements must be taken often enough so that at least 10 measurements are reported during the core phase of the workload.
 Each of these required equally spaced measurements required for Level 2 must be a power-averaged measurement over the entire separating space. 
 
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 2 Power Submission. 

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -17,7 +17,7 @@ information when you run your workload.
 \addcontentsline{toc}{subsection}{Quality Level}
 
 Choosing a quality level is the first important decision a submitter must make. Refer to 
-Section~\ref{sec:AQLevels} Aspect and Quality Levels for general information about the three quality levels.  
+Section~\numnameref{sec:AQLevels} for general information about the three quality levels.  
 Sections~\ref{sec:A1GTRM} through \ref{sec:A4wEMaT} describe the details of the three quality levels
 
 \item[{[ ]}]
@@ -25,11 +25,10 @@ Sections~\ref{sec:A1GTRM} through \ref{sec:A4wEMaT} describe the details of the 
 \addcontentsline{toc}{subsection}{Power Measurement Locations}
 
 Measurements of power or energy are often made at multiple locations in parallel across the computer system. A typical location might be the output of the building transformer.
-Refer to Section~\ref{sec:A4wEMaT}, \nameref{sec:A4wEMaT}
-for more information about power measurement locations.
+Refer to Section~\numnameref{sec:A4wEMaT} for more information about power measurement locations.
 
-Note that in some cases, you may have to adjust for power loss. For information about power loss, refer to 
-Section~\ref{sec:AfPL} Adjusting for Power Loss.  If you adjust for power loss, how you determined the power losses must be part of the submission.
+Note that in some cases, you may have to adjust for power loss. For information about power loss, refer to Section~\numnameref{sec:AfPL}.
+If you adjust for power loss, how you determined the power losses must be part of the submission.
 
 
 \newpage
@@ -63,7 +62,7 @@ The submitted value must be the average of all power readings taken during the c
 Refer to Section~\ref{sec:PAaTEM} for information on power averaged measurements.
 The core phase is required to run for at least one minute.
 
-Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level~1 power submission.
+Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~1 power submission.
 
 For Level~1, both the compute-node subsystem and the interconnect must be reported.  
 The compute-node subsystem power must be measured. 
@@ -79,7 +78,7 @@ For some systems, it may be impossible not to include a power contribution from 
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
 If the compute-node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
-Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
+Section~\numnameref{sec:A3SIiIP} for information about heterogeneous sets of compute nodes.
 
 \newpage
 \item[{[ ]}]
@@ -99,7 +98,7 @@ For this purpose, a series of equally spaced power-averaged measurements of equa
 These power-averaged measurements must be taken often enough so that at least 10 measurements are reported during the core phase of the workload.
 Each of these required equally spaced measurements required for Level~2 must be a power-averaged measurement over the entire separating space. 
 
-Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level~2 Power Submission. 
+Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~2 Power Submission. 
 
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
@@ -125,17 +124,16 @@ The measured energy is the last measured total energy within the core phase minu
 The final power is calculated by dividing this energy by the elapsed time between these first and last energy readings.
 These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 
-Refer to Section~\ref{sec:PAaTEM} Power-Averaged and Total Energy Measurements for information about the distinction between energy and power.
+Refer to Section~\numnameref{sec:PAaTEM} for information about the distinction between energy and power.
 
 The complete set of total energy readings used to calculate average power (at least 10 during the core computation phase) must be included, along with the execution time for the core phase and the execution time for the full run.
 
-Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more 
-information about the Level~3 Power Submission.
+Refer to Section~\numnameref{sec:A1GTRM} for more information about the Level~3 Power Submission.
 
-Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
+Refer to Section~\numnameref{sec:FoRM} for more information about the format of reported measurements.
 
 For Level~3, all subsystems participating in the workload must be measured. Refer to 
-Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for more information about included subsystems.
+Section~\numnameref{sec:A3SIiIP} for more information about included subsystems.
 
 With Level~3, the submitter need not be concerned about different types of compute nodes because Level~3 measures the entire system.
 
@@ -180,9 +178,9 @@ The submission must include the relevant manufacturer specifications and formula
 
 Include additional subsystems if needed.
 
-Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for more information about included subsystems.
+Refer to Section~\numnameref{sec:A3SIiIP} for more information about included subsystems.
 
-Refer to Section~\ref{sec:A2MFI} Aspect 2: Machine Fraction Instrumented for information about \% requirements for Levels 1 and 2.
+Refer to Section~\numnameref{sec:A2MFI} for information about \% requirements for Levels 1 and 2.
  
 \item[{[ ]}]
 \textbf{Tunable Parameters}
@@ -203,6 +201,6 @@ If you report tunable parameters, submit both the default value (the value that 
 Reporting information about the cooling system temperature is optional.
 It is requested to provide a description of the cooling system as well as where and how the temperature was measured.
 
-Refer to Section~\ref{sec:EF} Environmental Factors for more information.
+Refer to Section~\numnameref{sec:EF} for more information.
 
 \end{itemize}

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -77,14 +77,8 @@ This may include infrastructure that is shared, but excludes that part that is n
 For some systems, it may be impossible not to include a power contribution from a certain subsystems that is not used for the benchmark run.
 In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
-<<<<<<< 2df1b8d75a3270f3ff230fbd9371256dd1b3b9b6
-If the compute node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
+If the compute-node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
 Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
-=======
-If the compute-node subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
-Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about
- heterogeneous sets of compute nodes.
->>>>>>> compute-node subsystem hyphenation
 
 \newpage
 \item[{[ ]}]

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -2,8 +2,8 @@
 
 
 \noindent
-This section contains a checklist for all the items of information you need 
-to consider when making a power measurement. 
+This section contains a checklist with an overview of all the items of information you need to consider when making a power measurement.
+Afterward, Section~\ref{sec:reporting} provides a detailed and more elaborate description of all these items.
 \wl
 
 \noindent

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -1,3 +1,4 @@
+\chapter{Checklist}
 \label{sec:checklist}
 
 \noindent

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -56,7 +56,7 @@ The workload must run on all compute nodes of the system. Level 3 measures the p
 \textbf{Level 1 Power Measurement}
 \addcontentsline{toc}{subsection}{Level 1 Power Measurement}
 
-Level 1 submissions submissions include the average power over the entire core phase of the run (see \ref{sec:core_phase} for definition of core phase).
+Level 1 submissions include the average power over the entire core phase of the run (see \ref{sec:core_phase} for definition of core phase).
 
 For Level 1, the power during the entire core phase must be sampled at least once per second.
 The submitted value must be the average of all power samples taken during the core phase of the run.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -67,9 +67,8 @@ Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported M
 
 For Level 1, both the compute-node subsystem and the interconnect must be reported.  
 The compute-node subsystem power must be measured. 
-For the compute subsystem measure a minimum of 2kW of power, 
-10\% of the system, or 15 nodes whichever is largest.
-It is allowed to measure either at least 40kW or the whole machine if smaller than the largest requirement.
+For the compute subsystem measure a minimum of 2~kW of power, 10\% of the system, or 15 nodes whichever is largest.
+Alternatively, it is allowed to measure either at least 40~kW or the whole machine.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
@@ -100,13 +99,14 @@ For this purpose, a series of equally spaced power-averaged measurements of equa
 These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
 Each of the required equally spaced measurements required for Level 2 must be a power-averaged measurement over the entire separating space. 
 
+
 Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported Measurement for more information about the Level 2 Power Submission. 
 
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
 For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
 As for level 1, estimation is performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
-Level 2 requires that the greater of $ \frac{1}{8} $ of the compute-node subsystem or 10 kW of power or 15 compute nodes be measured.
+Level 2 requires that the greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW of power or 15 compute nodes be measured.
 It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
 The compute-node subsystem is the set of compute nodes. As with Level 1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
@@ -164,13 +164,13 @@ For Level 1, both the compute-node subsystem and the interconnect must be report
 The compute-node subsystem power must be measured. 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 
-Measure the greater of at least 2kW of power or $ \frac{1}{10} $ of the compute-node subsystem or 15 compute nodes.
+Measure the greater of at least 2~kW of power or $\frac{1}{10}$ of the compute-node subsystem or 15 compute nodes.
 
 \item
 For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
-The Measured \% and the Derived \% must sum to the Total \%.
+The Measured~\% and the Derived~\% must sum to the Total~\%.
 
-Measure the greater of at least 10kW of power or $ \frac{1}{8} $ of the compute-node subsystem or 15 compute nodes.
+Measure the greater of at least 10~kW of power or $\frac{1}{8}$ of the compute-node subsystem or 15 compute nodes.
 
 \item
 For Level 3, all subsystems participating in the workload must be measured completely.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -164,6 +164,8 @@ For Level 1, both the compute-node subsystem and the interconnect must be report
 The compute-node subsystem power must be measured. 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 
+Measure the greater of at least 2kW of power or $ \frac{1}{10} $ of the compute-node subsystem or 15 compute nodes.
+
 \item
 For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured and, if not measured, their contribution must be estimated.
 The Measured \% and the Derived \% must sum to the Total \%.
@@ -171,7 +173,7 @@ The Measured \% and the Derived \% must sum to the Total \%.
 Measure the greater of at least 10kW of power or $ \frac{1}{8} $ of the compute-node subsystem or 15 compute nodes.
 
 \item
-For Level 3, all subsystems participating in the workload must be measured.
+For Level 3, all subsystems participating in the workload must be measured completely.
 \end{itemize}
 
 Estimation must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.

--- a/text/checklist.tex
+++ b/text/checklist.tex
@@ -72,11 +72,12 @@ For the compute subsystem measure a minimum of 2kw of power,
 It is allowed to measure either at least 40kw or the whole machine if smaller than the largest requirement.
 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
+Estimation is performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
 This may include infrastructure that is shared, but excludes that part that is not servicing the current cluster.
 
-For some systems, it may be impossible not to include a power contribution from some subsystems. 
-In this case, list what you are including, but do not subtract an estimated value for the included subsystem.
+For some systems, it may be impossible not to include a power contribution from some subsystems that are not used for the benchmark run.
+In this case, list what you are including, but do not subtract an estimated value for the subsystem that are not needed.
 
 If the compute node-subsystem contains different types of compute nodes, measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to 
 Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
@@ -103,8 +104,10 @@ Refer to Section~\ref{sec:A1GTRM} Aspect 1: Granularity, Timespan and Reported M
 
 Refer to Section~\ref{sec:FoRM} for more information about the format of reported measurements.
 
-For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated. Level 2 requires that the 
-greater of $ \frac{1}{8} $ of the compute-node subsystem or 10 kW of power or 15 compute nodes be measured. It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
+For Level 2, the compute node subsystem must be measured and all other subsystems participating in the workload must be measured or estimated.
+As for level 1, estimation is performed by substituting the measurement by an uppower bound derrived from the maximum specified power consumption of all hardware components.
+Level 2 requires that the greater of $ \frac{1}{8} $ of the compute-node subsystem or 10 kW of power or 15 compute nodes be measured.
+It is acceptable to exceed this requirement or to measure the whole machine if smaller than 15 nodes.
 
 The compute-node subsystem is the set of compute nodes. As with Level 1, if the compute-node subsystem contains different types of compute nodes, you must measure at least one member from each of the heterogeneous sets. The contribution from compute nodes not measured must be extrapolated. Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for information about heterogeneous sets of compute nodes.
 

--- a/text/conclusion.tex
+++ b/text/conclusion.tex
@@ -2,7 +2,8 @@
 \label{sec:conclusion}
 
 \noindent
-This document specifies a methodology for measuring power that is used in conjunction with workload(s) to support the use of metrics that characterize the energy efficiency of high performance computing (HPC) systems as a function of both computational work accomplished and power consumed. It reflects a convergence of ideas and a reflection of best practices that form the basis for comparing and evaluating individual systems, product lines, architectures and vendors. 
+This document specifies a methodology for measuring power that is used in conjunction with workload(s) to support the use of metrics that characterize the energy efficiency of high performance computing (HPC) systems as a function of both computational work accomplished and power consumed.
+It reflects a convergence of ideas and a reflection of best practices that form the basis for comparing and evaluating individual systems, product lines, architectures and vendors.
 \wl
 
 \noindent

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -30,13 +30,12 @@ Time Protocol (NTP) is a networking protocol for clock synchronization between c
 
 \paragraph*{Power-Averaged Measurement}
 \begin{quote}
-A measurement taken by a device that samples the instantaneous power used by a system at some fine
-time resolution (say, once per second) for a given interval (say, 10 minutes).  The power averaged
-measurement for the interval is the numerical average of all the instantaneous power measurements
-during that interval, and constitutes one reported measurement covering that interval.
+A power-averaged measuremend over a certain time is the numerical average of all power readings of a power meter reported during that time.
+The power meter internally samples the instantaneous power used by a system at some fine time resolution (say, once per second).
+The power meter either reports every such power sample as power reading or average all power samples taken during a certain interval and then report only one single power reading as measurement for that interval.
 \end{quote}
 
-\paragraph*{Sampling}
+\paragraph*{Sampling and Power Readings}
 \begin{quote}
 Sampling delivered electrical power in a DC context refers to a single simultaneous measurement
 of the voltage and the current to determine the delivered power at that point.  The sampling
@@ -45,6 +44,10 @@ Sampling in an AC context requires a measurement stage, whether analog or digita
 the true power delivered at that point and enters that value into a buffer where it is then used
 to calculate average power over a longer time.  So ``sampled once per second'' in this context
 means that the times in the buffer are averaged and recorded once per second.
+
+The power meter may either report every power sample that is measured.
+In that case, power sample and power reading are the same.
+Or the power meter may internally average all power samples over a certain interval and then report only one power reading covering that entire interval.
 \end{quote}
 
 \paragraph*{Workload}

--- a/text/definitions.tex
+++ b/text/definitions.tex
@@ -9,7 +9,8 @@ The core phase is defined as the time period that is used for the performance ca
 
 \paragraph*{CSV file}
 \begin{quote}
-A comma-separated values (CSV) file stores tabular data (numbers and text) in plain-text form. A CSV file is readable by most spreadsheet programs.
+A comma-separated values (CSV) file stores tabular data (numbers and text) in plain-text form.
+A CSV file is readable by most spreadsheet programs.
 \end{quote}
 
 \paragraph*{Metric}
@@ -37,13 +38,10 @@ The power meter either reports every such power sample as power reading or avera
 
 \paragraph*{Sampling and Power Readings}
 \begin{quote}
-Sampling delivered electrical power in a DC context refers to a single simultaneous measurement
-of the voltage and the current to determine the delivered power at that point.  The sampling
-rate in this case is how often such a sample is taken and recorded internally within the device.
-Sampling in an AC context requires a measurement stage, whether analog or digital, that determines
-the true power delivered at that point and enters that value into a buffer where it is then used
-to calculate average power over a longer time.  So ``sampled once per second'' in this context
-means that the times in the buffer are averaged and recorded once per second.
+Sampling delivered electrical power in a DC context refers to a single simultaneous measurement of the voltage and the current to determine the delivered power at that point.
+The sampling rate in this case is how often such a sample is taken and recorded internally within the device.
+Sampling in an AC context requires a measurement stage, whether analog or digital, that determines the true power delivered at that point and enters that value into a buffer where it is then used to calculate average power over a longer time.
+So ``sampled once per second'' in this context means that the times in the buffer are averaged and recorded once per second.
 
 The power meter may either report every power sample that is measured.
 In that case, power sample and power reading are the same.

--- a/text/intro.tex
+++ b/text/intro.tex
@@ -30,7 +30,7 @@ Machine fraction instrumented
 \item 
 Subsystems included in instrumented power
 \item 
-Where in the power distribution network the measurements are taken, and accuracy of power meters.
+The location of measurement in the power distribution network and accuracy of power meters.
 \end{packed_enum}
 
 \noindent

--- a/text/intro.tex
+++ b/text/intro.tex
@@ -38,11 +38,11 @@ The quality ratings are as follows:
 
 \begin{packed_item}
 \item 
-Adequate, called Level 1 (L1)
+Adequate, called Level~1 (L1)
 \item
-Moderate, called Level 2 (L2)
+Moderate, called Level~2 (L2)
 \item
-Best, called Level 3 (L3)
+Best, called Level~3 (L3)
 \end{packed_item}
 
 \noindent

--- a/text/intro.tex
+++ b/text/intro.tex
@@ -9,7 +9,7 @@ running a workload.
 
 \noindent
 This document is part of a collaborative effort between the Green500, the Top500, 
-the Green Grid, and the Energy Efficient High Performance Computing Working Group.  While 
+the Green Grid, and the Energy Efficient High Performance Computing Working Group (EEHPC WG).  While 
 it is intended for this methodology to be generally applicable to benchmarking a variety of 
 workloads, the initial focus is on High Performance LINPACK (HPL). 
 \wl

--- a/text/intro.tex
+++ b/text/intro.tex
@@ -2,21 +2,17 @@
 \label{sec:intro}
 
 \noindent
-This document recommends a methodological approach for measuring, recording, and reporting the power used by a high performance 
-computer (HPC) system while
-running a workload. 
+This document recommends a methodological approach for measuring, recording, and reporting the power used by a high performance computer (HPC) system while running a workload.
 \wl
 
 \noindent
-This document is part of a collaborative effort between the Green500, the Top500, 
-the Green Grid, and the Energy Efficient High Performance Computing Working Group (EEHPC WG).  While 
-it is intended for this methodology to be generally applicable to benchmarking a variety of 
-workloads, the initial focus is on High Performance LINPACK (HPL). 
+This document is part of a collaborative effort between the Green500, the Top500, the Green Grid, and the Energy Efficient High Performance Computing Working Group (EEHPC WG).
+While it is intended for this methodology to be generally applicable to benchmarking a variety of workloads, the initial focus is on High Performance LINPACK (HPL).
 \wl
 
 \noindent
-This document defines four aspects of a power measurement and three quality ratings. All 
-four aspects have increasingly stringent requirements for higher quality levels.  
+This document defines four aspects of a power measurement and three quality ratings.
+All four aspects have increasingly stringent requirements for higher quality levels. 
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -64,12 +64,13 @@ For meters accepted by the spec power, refer to the {\itshape Power and Temperat
 \noindent
 Levels 1 and 2 specify power measurements. Level 3 specifies an energy measurement, but reports a power value.
 
-\subsection{Sampling}
+\subsection{Sampling and Power Readings}
 \noindent
 For Levels 1 and 2, the power meter must internally sample the instantaneous power at a constant frequency of at least once per second.
-The actual measurements that constitute a sample may be taken much more frequently than once per second.
+(Internally, one such power sample will usually require many more measurements of voltage and current taken much more frequently than once per second.
+The power meter will either integrate the measurements at a high frequency, or fit a sinus wave curve to it and determine the power factor and in this way produce a power consumption reading.)
 Usually the net frequency varies by a small percentage around 50~Hz or 60~Hz.
-It is allowed that the measurement frequency is not strictly constant, but it can be adjusted such that each sample interval covers a certain number of full sinus waves.
+It is allowed that the measurement sample frequency is not strictly constant, but it can be adjusted such that each sample interval covers a certain number of full sinus waves.
 In that case, the intervals must not exceed one second by more than one sinus wave and when building the final power average the power readings must be weighted by the duration of the sample interval.
 \wl
 
@@ -81,6 +82,20 @@ Sampling delivered electrical power in a DC context refers to a single simultane
 \noindent
 If the submitter is sampling in a DC context, most likely it will be necessary to adjust for power loss in the AC/DC conversion stage. 
 Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for details.
+\wl
+
+\noindent
+It is allowed that the power meter does not report every sample.
+Instead, the power meter may use an internal buffer and aggregate several samples over time and then only report one average power reading at a certain constant frequency.
+In the following, we refer to such a reported power measurement of the power meter as ``power reading''.
+It is required that the power meter reports at least one power reading every 10 seconds for level 2 and every minute for level 1.
+If the power meter reports every sample, then a power sample and a power reading is the same.
+\wl
+
+\noindent
+The power meter must use all power samples taken during an interval to compute the average power reading.
+Consider that the limits of one sample per second and one power reading per 10 seconds / 1 minute are upper bounds.
+Usually, the power meter will take many samples per second and report power readings on about a per second basis.
 
 \subsection{Power-Averaged and Total Energy Measurements}
 \label{sec:PAaTEM}
@@ -92,31 +107,32 @@ This subsection describes the difference of power-averaged measurements as requi
 \noindent
 The reported power values for Levels 1 and 2 are power-averaged measurements over a certain time period (e.g. the core phase or the full run).
 A power-averaged measurement is one taken by a device that samples the instantaneous power used by a system at some fine time resolution for a specified interval.
+This interval is short compared to the full time of the power-averaged measurement.
 The power meter device numerically averages of all the instantaneous power measurements sampled during that interval.
-This constitutes one reported measurement covering that interval.
-Finally, the power-averaged measurement for the required time period is the average of the power measurements obtained from the device in that period.
+This constitutes one measurement reported by the device covering that interval.
+Finally, the power-averaged measurement for the required time period is the average of all these power readings obtained from the device in that period.
 All power readings reported by the device for that period must be used except for one case:
 Exclude those readings for intervals that do not lie completely in the requested time period.
+(Usually the reading intervals and the measured time period (e.g. the core phase) are not synchronized.)
 We require that the internal device sampling frequncy must be at least 1 Hz and constant.
-Also the measurement intervals must be of constant length and no longer than 10 seconds.
+The intervals between the power readings must be constant and no longer than 1 minute for level 1 and 10 seconds for level 2.
+In any case the intervals between the power readings must not be longer than 1\% of the duration of the core phase.
+(This ensures that the parts of the core phase that are not measured at beginning and end are short.)
 As noted in the previous subsection, the frequency may vary slightly to accomodate for variations in the net frequency.
 In that case, the averaging process must weight the power readings from the power meter according to the respective interval lengths.
 \wl
 
 \noindent
-For instance, a meter may sample internally at 1 Hz and report one power reading every 5 seconds.
-Then, the measurement of the core phase is the average of all these power readings obtained every 5 seconds.
-\wl
-
-\noindent
 Consider Level 1, which requires only one reported power value. 
-This reported power value may consist of several power measurements taken at a constant frequency of at least once per second and averaged over an interval.
+This reported power value may consist of several power readings taken at a constant frequency of at least once per minute.
+Each such reading itself must be the average of instantaneous power samples measured at least once per second and averaged over reading interval.
 For Level 1, the time period that is measured must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
 For example, if the device reports one power measurement every 5 seconds (each being the average of at least 5 power samples) and the core phase takes 10 minutes, Level 1 reports one power-averaged value that averages over all the 120 measurements obtained during the core phase.
+(Usually the power reading intervals and the core phase are not synchronized, such that the first reding does not lie completely in the core phase. In that case the average is only over the 119 readings completely in the core phase.)
 \wl
 
 \noindent
-Level 2 also requires that power measurements be taken at a constant frequency and device must internally sample at least once per second.
+Level 2 also requires that power measurements be taken at a constant frequency and the device must internally sample internally at least once per second.
 It requires the submission of the power-averaged measurement for the core phase, for the full run, and for a series of equally spaced power-averaged measurements of equal length during the full run.
 These power-averaged measurements in the series must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
 There must not be any delay between the power measurement in this series and they must cover the entire core phase.
@@ -124,9 +140,9 @@ Alternatively, instead of the 10 power-averaged measurements, it is allowed to s
 \wl
 
 \noindent
-The measurement for the core phase is identical to the measurement in Level 1.
+The measurement for the core phase for Level 2 is identical to the measurement in Level 1.
 Assume again one measurement every 5 seconds (consisting of 5 samples each), a core phase of 10 minutes and a full run of 15 minutes.
-In that case, the submission includes one power-averaged measurement over 120 power readings for the core phase, one power-averaged measurement over 180 readings for the full run, and for instance a series of 15 power-averaged measurements over 12 power readings each, once per minute.
+In that case, the submission includes one power-averaged measurement over 120 power readings for the core phase, one power-averaged measurement over 180 readings for the full run, and for instance a series of 30 power-averaged measurements over 6 power readings each, once every 30 seconds.
 \wl
 
 \noindent
@@ -163,8 +179,8 @@ Table~\ref{tab:levels} summarizes the aspect and quality levels introduced in Se
 \textbf{Aspect}&\textbf{Level 1}&\textbf{Level 2}&\textbf{Level 3}\\ \hline
 
 \textbf{1a:~Granularity} &
-One power sample per second &
-One power sample per second &
+One power sample per second, one reported power reading per minute &
+One power sample per second, one reported power reading per 10 seconds &
 Continuously integrated energy\\
 \hline
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -68,10 +68,10 @@ Levels 1 and 2 specify power measurements. Level 3 specifies an energy measureme
 \noindent
 For Levels 1 and 2, the power meter must internally sample the instantaneous power at a constant frequency of at least once per second.
 (Internally, one such power sample will usually require many more measurements of voltage and current taken much more frequently than once per second.
-The power meter will either integrate the measurements at a high frequency, or fit a sinus wave curve to it and determine the power factor and in this way produce a power consumption reading.)
+The power meter will either integrate the measurements at a high frequency, or fit a sine wave curve to it and determine the power factor and in this way produce a power consumption reading.)
 Usually the net frequency varies by a small percentage around 50~Hz or 60~Hz.
-It is allowed that the measurement sample frequency is not strictly constant, but it can be adjusted such that each sample interval covers a certain number of full sinus waves.
-In that case, the intervals must not exceed one second by more than one sinus wave and when building the final power average the power readings must be weighted by the duration of the sample interval.
+It is allowed that the measurement sample frequency is not strictly constant, but it can be adjusted such that each sample interval covers a certain number of full sine waves.
+In that case, the intervals must not exceed one second by more than one sine wave and when building the final power average the power readings must be weighted by the duration of the sample interval.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -88,7 +88,7 @@ Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented
 It is allowed that the power meter does not report every sample.
 Instead, the power meter may use an internal buffer and aggregate several samples over time and then only report one average power reading at a certain constant frequency.
 In the following, we refer to such a reported power measurement of the power meter as ``power reading''.
-It is required that the power meter reports at least one power reading every 10 seconds for level 2 and every minute for level 1.
+The intervals between the power readings must be no longer than 10\% of the duration of the core phase.
 If the power meter reports every sample, then a power sample and a power reading is the same.
 \wl
 
@@ -115,9 +115,8 @@ All power readings reported by the device for that period must be used except fo
 Exclude those readings for intervals that do not lie completely in the requested time period.
 (Usually the reading intervals and the measured time period (e.g. the core phase) are not synchronized.)
 We require that the internal device sampling frequncy must be at least 1 Hz and constant.
-The intervals between the power readings must be constant and no longer than 1 minute for level 1 and 10 seconds for level 2.
-In any case the intervals between the power readings must not be longer than 1\% of the duration of the core phase.
-(This ensures that the parts of the core phase that are not measured at beginning and end are short.)
+The intervals between the power readings must be constant and no longer than 10\% of the duration of the core phase.
+(This ensures that the parts of the core phase that are not measured at beginning and end are not significant.)
 As noted in the previous subsection, the frequency may vary slightly to accomodate for variations in the net frequency.
 In that case, the averaging process must weight the power readings from the power meter according to the respective interval lengths.
 \wl
@@ -179,8 +178,8 @@ Table~\ref{tab:levels} summarizes the aspect and quality levels introduced in Se
 \textbf{Aspect}&\textbf{Level 1}&\textbf{Level 2}&\textbf{Level 3}\\ \hline
 
 \textbf{1a:~Granularity} &
-One power sample per second, one reported power reading per minute &
-One power sample per second, one reported power reading per 10 seconds &
+One power sample per second &
+One power sample per second &
 Continuously integrated energy\\
 \hline
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -20,9 +20,9 @@ This section defines meter accuracy requirements.
 \wl
 
 \noindent
-For Level~3, it is required to use any revenue grade meter, any meter accepted by SPEC power, or any meter documented to have an accuracy of 1\% or better.
-Level~2 requires a meter with a minimum documented accuracy of 2\%.
-Level~1 requires a meter with a minimum documented accuracy of 5\%.
+For Level~3, it is required to use any revenue grade meter, any meter accepted by SPEC power, or any meter documented to have an accuracy of \SpecAccuracyLThree{} or better.
+Level~2 requires a meter with a minimum documented accuracy of \SpecAccuracyLTwo{}.
+Level~1 requires a meter with a minimum documented accuracy of \SpecAccuracyLOne{}.
 \wl
 
 \noindent
@@ -41,14 +41,14 @@ For Levels~1 and~2 it is allowed to assume that the AC net power is a sine wave 
 If the site uses multiple independent power meters for a Level~2 or a Level~3 measurement, and if all employed power meters measure an identical fraction of the system, the requirements are relaxed in the following way.
 \begin{packed_item}
 \item 
-Each individual power meter must have at least a documented accuracy of 3\%.
+Each individual power meter must have at least a documented accuracy of \SpecAccuracyMeter{}.
 \item
-The documented error of the individual meters divided by the square root of the number of employed meters must meet the above requirements of 2\% for Level~2 and 1\% for Level~1.
+The documented error of the individual meters divided by the square root of the number of employed meters must meet the above requirements of \SpecAccuracyLTwo{} for Level~2 and \SpecAccuracyLThree{} for Level~3.
 \end{packed_item}
 In this case, the second requirement ensures that the standard deviation of the measurement of the entire run, using error propagation, and assuming a gaussian distribution, and assuming that the errors of the power meters are uncorelated, meets the requirements.
 For example, assume 4 power meters for a Level~3 measurement, each measuring 25\% of the total system.
-In that case, each meter must have a documented accuracy of~$1\% \cdot \sqrt{4} = 2\%$.
-In other words, you can use a single meter with 1\% accuracy, 4 meters with 2\% accuracy, or 9 meters with 3\% accuracy for Level~3.
+In that case, each meter must have a documented accuracy of~$1\% \cdot \sqrt{4} = 2\%$ to get a final accuracy of~1\%.
+In other words, you can use a single meter with 1\% accuracy, 4 meters with 2\% accuracy, or 9 meters with 3\% accuracy to reach~1\% for Level~3.
 \wl
 
 \noindent
@@ -100,7 +100,7 @@ Refer to Section~\numnameref{sec:A3SIiIP} for details.
 It is allowed that the power meter does not report every power sample it takes.
 Instead, the power meter may use an internal buffer and aggregate several samples over time and then only report one average power reading at a certain constant frequency.
 In the following, we refer to such a reported power measurement of the power meter as ``power reading''.
-The intervals between the power readings must be no longer than 10\% of the duration of the core phase.
+The intervals between the power readings must be no longer than \MaxReadingIntervalCorePhaseLTwoThree{} of the duration of the core phase.
 If the power meter reports every sample, then a power sample and a power reading are the same.
 \wl
 
@@ -127,7 +127,7 @@ All power readings reported by the device for that period must be used except fo
 Exclude those readings for intervals that do not lie completely in the requested time period.
 (Usually the reading intervals and the measured time period (e.g.~the core phase) are not synchronized.)
 We require that the internal device sampling rate must be at least 1 Hz and constant.
-The intervals between the power readings must be constant and no longer than 10\% of the duration of the core phase.
+The intervals between the power readings must be constant and no longer than \MaxReadingIntervalCorePhaseLTwoThree{} of the duration of the core phase.
 (This ensures that the parts of the core phase that are not measured at beginning and end are not significant.)
 As noted in the previous subsection, the sampling rate may vary slightly to accomodate for variations in the net frequency.
 In that case, the averaging process must weight the power readings from the power meter according to the respective interval lengths.
@@ -135,7 +135,7 @@ In that case, the averaging process must weight the power readings from the powe
 
 \noindent
 Consider Level~1, which requires only one reported power value.
-This reported power value may consist of several power readings taken at a constant frequency with interval length shorter than 10\% of the core phase.
+This reported power value may consist of several power readings taken at a constant frequency with interval length shorter than \MaxReadingIntervalCorePhaseLTwoThree{} of the core phase.
 Each such reading itself must be the average of instantaneous power samples measured at least once per second and averaged over the reading interval.
 For Level~1, the time period that is measured must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
 For example, if the device reports one power measurement every 5 seconds (each being the average of at least 5 power samples) and the core phase takes 10 minutes, Level~1 reports one power-averaged value that averages over all the 120 measurements obtained during the core phase.
@@ -146,7 +146,7 @@ In that case the average is only over the 119 readings completely in the core ph
 \noindent
 Level~2 also requires that power readings be taken at a constant frequency and the device must internally sample internally at least once per second.
 It requires the submission of the power-averaged measurement for the core phase (as Level~1 does), for the full run, and for a series of power-averaged measurements of equal length at regular intervals during the full run.
-The measurement interval must be short enough so that at least 10 measurements are reported during the core phase of the workload.
+The measurement interval must be short enough so that at least \MinMeasurementsCorePhaseLTwoThree{} measurements are reported during the core phase of the workload.
 There must be no gap between these regular measurements, i.e. this series of measurements in total must cover the full run.
 Alternatively, instead of this series of power-averaged measurements, it is allowed to submit the full set of power readings from the device that are used to calculate the average power during the core phase and during the full run.
 \wl
@@ -168,12 +168,12 @@ Level~3 specifies a total energy measurement that, when divided by the measured 
 An integrated measurement is a continuing sum of energy measurements.
 The measuring device samples voltage and current many times per second and integrates those samples to determine the next total energy consumed reading.
 Typically, there are hundreds of measurements per second.
-It is requested that the power meter samples voltage and current at least at 120~Hz for a DC measurement and at least at~5kHz for an AC measurement.
+It is requested that the power meter samples voltage and current at least at~\SpecRateLThreeDC{} for a DC measurement and at least at~\SpecRateLThreeAC{} for an AC measurement.
 \wl
 
 \noindent
-Level~3 reports an average power value for the core phase, an average power value for the whole run, at least 10 energy values at regular intervals within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
-These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
+Level~3 reports an average power value for the core phase, an average power value for the whole run, at least \MinMeasurementsCorePhaseLTwoThree{} energy values at regular intervals within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
+These last and first measurements in the core phase must be timed such that no more than a total of \MaxSecMissingLThree{}~seconds (\MaxSecMissingLThreeHalf{}~seconds each at begin and end) of the core phase are not covered by the total energy measurement.
 The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
 The final value for the full run must be obtained analogously.
 \wl
@@ -218,8 +218,8 @@ $\bullet$ Full run average power &
 $\bullet$ Full run total energy \\
 
  & &
-$\bullet$ 10 average power measurements in the core phase &
-$\bullet$ 10 total energy measureMDSpecsments in the core phase \\
+$\bullet$ \MinMeasurementsCorePhaseLTwoThree{} average power measurements in the core phase &
+$\bullet$ \MinMeasurementsCorePhaseLTwoThree{} total energy measureMDSpecsments in the core phase \\
 
  & &
 $\bullet$ idle power &
@@ -227,8 +227,8 @@ $\bullet$ idle power \\
 \hline
 
 \textbf{2: Machine \newline fraction}  &
-The greater of $\frac{1}{10}$ of the compute subsystem or 2~kW or 15~compute nodes - alternatively at least 40~kW or the entire system &
-The greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW or 15~compute nodes - alternatively the entire system &
+The greater of \SpecFracMinLOne{} of the compute subsystem or \SpecPowerMinLOne{} or \SpecMinNodes{}~compute nodes - alternatively at least \SpecPowerMaxLOne{} or the entire system &
+The greater of \SpecFracMinLTwo{} of the compute-node subsystem or \SpecPowerMinLTwo{} or \SpecMinNodes{}~compute nodes - alternatively the entire system &
 The whole of all included subsystems \\
 \hline
 
@@ -254,9 +254,9 @@ Conversion loss modeled with off-line measurements of a single power supply &
 Conversion loss measured simultaneously \\
 \hline
 \textbf{4b: Meter accuracy} &
-5\% &
-2\% (see Section~\ref{sec:MDSpecs})&
-1\% (see Section~\ref{sec:MDSpecs})\\
+\SpecAccuracyLOne{} &
+\SpecAccuracyLTwo{} (see Section~\ref{sec:MDSpecs})&
+\SpecAccuracyLThree{} (see Section~\ref{sec:MDSpecs})\\
 \hline
 \end{tabular}
 \end{table}
@@ -281,7 +281,7 @@ This aspect describes how the power measurements are reported.
 
 \noindent
 For all required measurements, the submission must also include the data used to calculate them.
-For Level~2 and Level~3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core phase of the run.
+For Level~2 and Level~3 submissions, the supporting data must include at least \MinMeasurementsCorePhaseLTwoThree{} measurement values at a regular sampling rate in the core phase of the run.
 \wl
 
 \noindent
@@ -297,7 +297,7 @@ This ensures that a uniform standard of \textit{beginning} and \textit{end} of t
 
 \noindent
 There is no maximum number of reported measurement values, although one reported measurement per second is a reasonable upper limit.
-The submitter may choose to include more than 10 such measurement values.
+The submitter may choose to include more than \MinMeasurementsCorePhaseLTwoThree{} such measurement values.
 \wl
 
 \noindent
@@ -419,7 +419,7 @@ The core phase is required to run for at least one minute.
 
 \noindent
 On top of these full measurements, a series of power-averaged measurements of equal length at regular intervals must be submitted for the full run.
-These intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload.
+These intervals must be short enough so that at least \MinMeasurementsCorePhaseLTwoThree{} measurements are reported during the core phase of the workload.
 There must be no gap between these regular measurements, i.e. this series of measurements in total must cover the full run.
 \wl
 
@@ -442,7 +442,7 @@ Level~3 submissions include a measurement of the average power during the core p
 \wl
 
 \noindent
-The complete set of total energy readings (at least 10 during the core computation phase) must be included, along with the execution time for the core phase and full run.
+The complete set of total energy readings (at least \MinMeasurementsCorePhaseLTwoThree{} during the core computation phase) must be included, along with the execution time for the core phase and full run.
 \wl
 
 \noindent
@@ -452,12 +452,12 @@ The readings must begin before the start of the run and extend to when it is fin
 
 \noindent
 The measuring device must sample voltage and current at high rate and integrate those samples to determine the next total energy consumed reading.
-The sampling rate must be at least 120~Hz for DC, and at least 5~kHz for AC.
+The sampling rate must be at least~\SpecRateLThreeDC{} for DC, and at least \SpecRateLThreeAC{} for AC.
 Sampling at a greater rate is permitted.
 \wl
 
 \noindent
-The intervals at which total energy readings are reported must be short enough so that at least 10 reported readings fall within the core phase of the workload.
+The intervals at which total energy readings are reported must be short enough so that at least \MinMeasurementsCorePhaseLTwoThree{} reported readings fall within the core phase of the workload.
 Note that each reported energy reading is the integral over many internal power samples.
 \wl
 
@@ -530,17 +530,17 @@ The requirements with respect to the compute-node subsystem for each quality lev
 
 \begin{itemize}
 \item
-L1: The largest of $\frac{1}{10}$ of the compute-node subsystem or at least 2~kW or 15 compute nodes.
-Alternatively, at least 40~kW or the entiry system.
+L1: The largest of \SpecFracMinLOne{} of the compute-node subsystem or at least \SpecPowerMinLOne{} or \SpecMinNodes{} compute nodes.
+Alternatively, at least \SpecPowerMaxLOne{} or the entiry system.
 \item
-L2: The largest of $\frac{1}{8}$ of the compute-node subsystem or at least 10~kW or 15 compute nodes.
+L2: The largest of \SpecFracMinLTwo{} of the compute-node subsystem or at least \SpecPowerMinLTwo{} or \SpecMinNodes{} compute nodes.
 Alternatively, the entire system if smaller than 15 nodes.
 \item
 L3: The power use of the whole machine must be measured.
 \end{itemize}
 
 \noindent
-For measurements of other subsystems (network, storage, etc.), measure at least $\frac{1}{10}$ for Level~1, $\frac{1}{8}$ for Level~2, and everything for Level~3.
+For measurements of other subsystems (network, storage, etc.), measure at least \SpecFracMinLOne{} for Level~1, \SpecFracMinLTwo{} for Level~2, and everything for Level~3.
 \wl
 
 \noindent
@@ -550,7 +550,7 @@ Even if individual node power could be measured, that would not be valid as it w
 \wl
 
 \noindent
-The requirements for Level~1 and Level~2 include the measurement of at least 15 nodes.
+The requirements for Level~1 and Level~2 include the measurement of at least \SpecMinNodes{} nodes.
 For a cluster consisting of individual servers, a node is simply defined as one server.
 There are architectures with multiple individual servers in one chassis, e.g.
 2U twin or twin$^2$ servers with 2 and 4 servers per chassis and blade servers with many more nodes in one chassis.
@@ -649,7 +649,7 @@ With Level~3, the submitter need not be concerned about heterogeneous sets of co
 \noindent
 Levels~1 and~2, however, measure a portion of the compute-node subsystem and estimate contributions from unmeasured portions.
 With Levels~1 and~2, the submitter must measure at least one member of each heterogeneous set.
-Measure at least 10\% of each heterogeneous set for Level~1, and at least $\frac{1}{8}$ of each heterogeneous set for Level~2.
+Measure at least \SpecFracMinLOne{} of each heterogeneous set for Level~1, and at least \SpecFracMinLTwo{} of each heterogeneous set for Level~2.
 Then, extrapolate the total power per each heterogeneous set as you would do for a non heterogeneous cluster.
 Finally, accumulate the contributions of all heterogeneous sets.
 \wl

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -176,8 +176,8 @@ The whole of all included subsystems \\
 \hline
 
 \textbf{3:~Subsystems} &
-Compute-nodes and measured or estimated interconnect &
-All participating subsystems, either measured or estimated &
+Compute-nodes measured, interconnect measured or estimated &
+Compute-nodes measured, all participating subsystems measured or estimated &
 All participating subsystem must be measured \\
 \hline
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -157,7 +157,7 @@ Level 3 specifies a total energy measurement that, when divided by the measured 
 
 \noindent
 Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
-These last and first measurements in the core phase must be timed such that no more than a total of two seconds (one each at begin and end) of the core phase are not covered by the total energy measurement.
+These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
 The final value for the full run must be obtained analogously.
 \wl

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -151,10 +151,15 @@ Level 3 specifies a total energy measurement that, when divided by the measured 
 \wl
 
 \noindent
+<<<<<<< 2e6c0c1b4d5155ec37469b3883dc8710baf352da
 Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
 These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
 The final value for the full run must be obtained analogously.
+=======
+
+Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power. An integrated measurement is a continuing sum of energy measurements. Typically, there are hundreds of measurements per second.  Depending on the local AC power line frequency, there must be at least 120 or 100 measurements per second. The measuring device samples voltage and current many times per second and integrate those samples to determine the next total energy consumed reading. 
+>>>>>>> Various clarifications
 \wl
 
 \noindent
@@ -395,7 +400,7 @@ Level 3 requires continuously integrated total energy measurements rather than p
 \wl
 
 \noindent
-The measuring device must sample voltage and current, whether AC or DC, at least 120 times or 100 times per second (depending on what the frequency standard in the current location is) and integrate those samples to determine the next total energy consumed reading.  Sampling at a greater rate is permitted. 
+The measuring device must sample voltage and current, whether AC or DC, at least 120 times or 100 times per second (depending on the local AC power line frequency) and integrate those samples to determine the next total energy consumed reading.  Sampling at a greater rate is permitted. 
 \wl
 
 \noindent
@@ -620,7 +625,7 @@ At the entry point to the first power-modifying component (for example, the Blue
 \end{itemize}
 
 \noindent
-If the measuring device or devices used to satisfy Aspect 1 also meet the ABC location requirements just specified above, then those devices are sufficient to obtain the measurements needed for submission.
+If the measuring device or devices used to satisfy Aspect 1 also meet the ABC location requirements specified above, then those devices are sufficient to obtain the measurements needed for submission.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -108,7 +108,7 @@ Usually, the power meter will take many samples per second and report power read
 
 This subsection describes the difference of power-averaged measurements as required for Level~1 and Level~2 as compared to total energy measurements as required for Level~3.
 
-\subsubsection{Power-Averaged Measurements}
+\subsubsection{Power-Averaged Measurements (Levels~1 and~2)}
 
 \noindent
 The reported power values for Levels~1 and~2 are power-averaged measurements over a certain time period (e.g.~the core phase or the full run).
@@ -155,7 +155,7 @@ In that case, the submission includes one power-averaged measurement over 120 po
 For Levels~1 and~2, the units of the reported power values are watts.
 \wl
 
-\subsubsection{Total Energy Measurements}
+\subsubsection{Total Energy Measurements (Level~3)}
 
 \noindent
 Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power.

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -205,8 +205,8 @@ $\bullet$ idle power \\
 \hline
 
 \textbf{2: Machine \newline fraction}  &
-The greater of 1/10 of the compute subsystem or 2~kW or 15~compute nodes. Alternatively at least 40~kW or the entire system. &
-The greater of 1/8 of the compute-node subsystem or 10~kW or 15~compute nodes &
+The greater of \frac{1}{10} of the compute subsystem or 2~kW or 15~compute nodes. Alternatively at least 40~kW or the entire system. &
+The greater of \frac{1}{8] of the compute-node subsystem or 10~kW or 15~compute nodes &
 The whole of all included subsystems \\
 \hline
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -89,6 +89,7 @@ If the power meter reports every sample, then a power sample and a power reading
 \wl
 
 \noindent
+<<<<<<< 6eeac015b98513fb43fe8cfe1f2adf00ae545965
 The power meter must use all power samples taken during an interval to compute the average power reading.
 Consider that the limits of one sample per second and one power reading per 10 seconds / 1 minute are upper bounds.
 Usually, the power meter will take many samples per second and report power readings on about a per second basis.
@@ -110,10 +111,10 @@ Finally, the power-averaged measurement for the required time period is the aver
 All power readings reported by the device for that period must be used except for one case:
 Exclude those readings for intervals that do not lie completely in the requested time period.
 (Usually the reading intervals and the measured time period (e.g. the core phase) are not synchronized.)
-We require that the internal device sampling frequncy must be at least 1 Hz and constant.
+We require that the internal device sampling rate must be at least 1 Hz and constant.
 The intervals between the power readings must be constant and no longer than 10\% of the duration of the core phase.
 (This ensures that the parts of the core phase that are not measured at beginning and end are not significant.)
-As noted in the previous subsection, the frequency may vary slightly to accomodate for variations in the net frequency.
+As noted in the previous subsection, the sampling rate may vary slightly to accomodate for variations in the net frequency.
 In that case, the averaging process must weight the power readings from the power meter according to the respective interval lengths.
 \wl
 
@@ -337,7 +338,7 @@ Note that the power drops by 8\% or so during the computational phase of the run
 \end{figure}
 
 \noindent
-The boxes are individual one-second power samples.  This fast up-down fluctuation is not caused by the behavior of an individual power supply; the power being sampled is over the entire computer system doing the HPL run.  The reason that L3 requires integrating total energy meters is because they measure at a high enough frequency to not be subject to these sampling artifacts.
+The boxes are individual one-second power samples.  This fast up-down fluctuation is not caused by the behavior of an individual power supply; the power being sampled is over the entire computer system doing the HPL run.  The reason that L3 requires integrating total energy meters is because they measure at a high enough sampling rates to not be subject to these sampling artifacts.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -408,7 +408,7 @@ The intervals at which total energy readings are reported must be short enough s
 Figure~\ref{fig:a1l3pm} illustrates Aspect~1 of  Level~3 power measurement. The figure shows 10 readings in the core phase of the workload. Note that these are integrated readings.  To obtain a power reading, one must subtract two integrated readings and divide by the time between the readings.
 
 %INCLUDE FIG 3-5
-\begin{figure}
+\begin{figure}[t]
 \centering
 \includegraphics[width=4in]{fig3-5}
 \caption{Aspect~1 of Level~3 Power Measurements}
@@ -457,9 +457,9 @@ The requirements with respect to the compute-node subsystem for each quality lev
 
 \begin{itemize}
 \item
-L1: $\frac{1}{10}$ of the compute-node subsystem or at least 2~kW or 15 compute nodes, whichever is greater. Alternatively, at least 40~kW or the entiry system.
+L1: The largest of $\frac{1}{10}$ of the compute-node subsystem or at least 2~kW or 15 compute nodes. Alternatively, at least 40~kW or the entiry system.
 \item
-L2: $\frac{1}{8}$ of the compute-node subsystem or at least 10~kW or 15 compute nodes, whichever is greater.
+L2: The largest of $\frac{1}{8}$ of the compute-node subsystem or at least 10~kW or 15 compute nodes.
 \item
 L3: the power use of the whole machine must be measured.
 \end{itemize}
@@ -514,7 +514,7 @@ For Level~1, both the compute-node subsystem and the interconnect must be report
 The compute-node subsystem power must be measured. 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
-This may include infrastructure that is shared, but excludes that part that is not servicing the current cluster.
+This may include infrastructure that is shared, but excludes parts that are not servicing the system under test.
 For some systems, it may be impossible not to include a power contribution from some subsystems. 
 In this case, provide a list of the measured subsystems, but do not subtract an estimated value for the included subsystem. 
 \wl
@@ -658,7 +658,7 @@ Submitters may find it useful to create such a schematic to identify the power m
 \centering
 \includegraphics[width=4in]{fig3-7}
 \caption{Example of a Power Measurement Schematic}
-(used with permission from Universit Laval, Calcul Qubec, Compute Canada)
+(used with permission from Universit\'{e} Laval, Calcul Qu\'{e}bec, Compute Canada)
 \label{fig:powmeasschem}
 \end{figure}
 
@@ -678,11 +678,11 @@ Other environmental data may include factors such as:
 
 \begin{packed_item}
 \item[{-}]
-\% deviation between supply and rated voltage and frequency (recommended +/-5\%)
+\% deviation between supply and rated voltage and frequency (recommended $\pm$\,5\%)
 \item[{-}]
-\% total harmonic distortion (recommended \textless 2\% THD )
+\% total harmonic distortion (recommended \textless\,2\% THD )
 \item[{-}]
-line impedance (recommended \textless 0.25 ohm)
+line impedance (recommended \textless\,0.25 ohm)
 \item[{-}]
 relative humidity
 \end{packed_item}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -60,7 +60,7 @@ For meters accepted by the spec power, refer to the {\itshape Power and Temperat
 \section{Measuring Device Terminology}
 \label{sec:MDTerm}
 \noindent
-Levels 1 and 2 specify power measurements.
+Levels~1 and~2 specify power measurements.
 Level~3 specifies an energy measurement, but reports a power value.
 
 \subsection{Sampling and Power Readings}
@@ -106,7 +106,7 @@ This subsection describes the difference of power-averaged measurements as requi
 \subsubsection{Power-Averaged Measurements}
 
 \noindent
-The reported power values for Levels 1 and 2 are power-averaged measurements over a certain time period (e.g.~the core phase or the full run).
+The reported power values for Levels~1 and~2 are power-averaged measurements over a certain time period (e.g.~the core phase or the full run).
 A power-averaged measurement is one taken by a device that samples the instantaneous power used by a system at some fine time resolution for a specified interval.
 This interval is short compared to the full time of the power-averaged measurement.
 The power meter device numerically averages of all the instantaneous power measurements sampled during that interval.
@@ -147,7 +147,7 @@ In that case, the submission includes one power-averaged measurement over 120 po
 \wl
 
 \noindent
-For Levels 1 and 2, the units of the reported power values are watts.
+For Levels~1 and~2, the units of the reported power values are watts.
 \wl
 
 \subsubsection{Total Energy Measurements}
@@ -169,7 +169,7 @@ The final value for the full run must be obtained analogously.
 
 \noindent
 The difference between the initial and final energy readings are the total energy measurement in joule.
-The reported values after the energy has been divided by the elapsed time are watts as for levels 1 and 2.
+The reported values after the energy has been divided by the elapsed time are watts as for Levels~1 and~2.
 
 \section{Aspect and Quality Levels}
 \label{sec:AQLevels}
@@ -250,7 +250,7 @@ Conversion loss measured simultaneously \\
 \end{tabular}
 \end{table}
 
-\section{Aspect 1: Granularity, Timespan and Reported Measurements}
+\section{Aspect~1: Granularity, Timespan and Reported Measurements}
 \label{sec:A1GTRM}
 \noindent
 Aspect~1 has the following three parts.
@@ -274,7 +274,7 @@ For Level~2 and Level~3 submissions, the supporting data must include at least 1
 \wl
 
 \noindent
-Levels 2 and 3 require reported measurement values at regular intervals for the following reasons:
+Levels~2 and~3 require reported measurement values at regular intervals for the following reasons:
 
 \begin{itemize}
 \item
@@ -339,7 +339,7 @@ Since HPL only reports the time spent executing the core phase of the workload, 
 \wl
 
 \noindent
-Levels 2 and 3 require the entire run to be measured and reported because HPL (the default workload at the time this document was written) drops significantly in power consumption during the course of a computation, as the matrix size being computed gets smaller.
+Levels~2 and~3 require the entire run to be measured and reported because HPL (the default workload at the time this document was written) drops significantly in power consumption during the course of a computation, as the matrix size being computed gets smaller.
 Requiring the entire run eliminates systematic bias caused by using different parts of the run for the measurement.
 Figure~\ref{fig:powprof} shows an example of a power graph taken from an HPL run on the LLNL Muir system in the fall of 2011.
 \wl
@@ -465,7 +465,7 @@ To obtain a power reading, one must subtract two integrated readings and divide 
 \section{Format of Reported Measurements}
 \label{sec:FoRM}
 \noindent
-Levels 2 and 3 require the complete set of measurements.
+Levels~2 and~3 require the complete set of measurements.
 The submitter may choose to provide these values in a CSV file.
 Do not provide scans of paper documents.
 \wl
@@ -484,7 +484,7 @@ Keep this graph for reference, but do not provide it as part of the submission.
 \label{fig:powengwl}
 \end{figure}
 
-\section{Aspect 2: Machine Fraction Instrumented}
+\section{Aspect~2: Machine Fraction Instrumented}
 \label{sec:A2MFI}
 \noindent
 Aspect~2 specifies the fraction of the system whose power feeds are instrumented by the measuring equipment.
@@ -496,8 +496,8 @@ Level~2 requires a higher fraction than Level~1.
 \wl
 
 \noindent
-Levels 1 and 2 do not measure the power of the entire system, but require only a measurement of a fraction of the system and estimate the total power consumotion by extrapolation.
-When calculating the average power of the full machine for Levels 1 and 2, the measured power must be divided by this fraction to 
+Levels~1 and~2 do not measure the power of the entire system, but require only a measurement of a fraction of the system and estimate the total power consumotion by extrapolation.
+When calculating the average power of the full machine for Levels~1 and~2, the measured power must be divided by this fraction to 
 extrapolate to the average power drawn by the whole machine.
 For example, if the submitter measures the power delivered 
 to $ \frac{1}{4} $ of the machine, the submitter must then multiply the measured power by 4 to obtain the power for the whole machine.
@@ -545,10 +545,10 @@ For instance, if you measure nodes then choose random nodes, if you measure enti
 It is not allowed to screen the system for components with lower power consumtion and then measure only that fraction nor is it allowed to replace components in the chosen fraction by ones with lower power consumption.
 \wl
 
-\section{Aspect 3: Subsystems Included in Instrumented Power}
+\section{Aspect~3: Subsystems Included in Instrumented Power}
 \label{sec:A3SIiIP}
 \noindent
-Aspect 3 specifies the subsystems included in the instrumented power.
+Aspect~3 specifies the subsystems included in the instrumented power.
 \wl
 
 \noindent
@@ -587,11 +587,11 @@ The reported power measurement must include all computational nodes, any interco
 \wl
 
 \noindent
-For Levels 1 and 2, estimations of other subsystems besides the compute subsystem must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
+For Levels~1 and~2, estimations of other subsystems besides the compute subsystem must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
 \wl
 
 \noindent
-For Levels 2 and 3, the reported power measurement may exclude storage subsystems that don't participate in the workload.
+For Levels~2 and~3, the reported power measurement may exclude storage subsystems that don't participate in the workload.
 It is not required to exclude such storage subsystems.
 However, if these storage subsystems are part of the cabinet or rack being measured, they may not be excluded even if they are not used.
 That is, the submitter cannot calculate their contribution and subtract that contribution.
@@ -624,8 +624,8 @@ With Level~3, the submitter need not be concerned about heterogeneous sets of co
 \wl
 
 \noindent
-Levels 1 and 2, however, measure a portion of the compute-node subsystem and estimate contributions from unmeasured portions.
-With Levels 1 and 2, the submitter must measure at least one member of each heterogeneous set.
+Levels~1 and~2, however, measure a portion of the compute-node subsystem and estimate contributions from unmeasured portions.
+With Levels~1 and~2, the submitter must measure at least one member of each heterogeneous set.
 Measure at least 10\% of each heterogeneous set for Level~1, and at least $\frac{1}{8}$ of each heterogeneous set for Level~2.
 Then, extrapolate the total power per each heterogeneous set as you would do for a non heterogeneous cluster.
 Finally, accumulate the contributions of all heterogeneous sets.
@@ -644,12 +644,12 @@ The total power measurement reported for compute nodes would then be
 \[ Total~power=2*(power~from~compute~nodes~A) + 4*(power~from~compute~nodes~B) \]
 
 \noindent
-The assumption of Levels 2 and 1 is that all the compute nodes in a set react identically to the workload.
+The assumption of Levels~1 and~2 is that all the compute nodes in a set react identically to the workload.
 
 
-\section{Aspect 4: Instrumentation Location where the Electrical Measurements are Taken}
+\section{Aspect~4: Instrumentation Location where the Electrical Measurements are Taken}
 \label{sec:A4wEMaT}
-Aspect 4 specifies where in the power distribution system the power delivery is measured.
+Aspect~4 specifies where in the power distribution system the power delivery is measured.
 For all quality levels, the submission indicates where power is measured and the quantity of parallel measurements.
 \wl
 
@@ -696,7 +696,7 @@ At the input connector to the first power-modifying component (for example, the 
 \end{itemize}
 
 \noindent
-If the measuring device or devices used to satisfy Aspect 1 also meet the ABC location requirements specified above, then those devices are sufficient to obtain the measurements needed for submission.
+If the measuring device or devices used to satisfy Aspect~1 also meet the ABC location requirements specified above, then those devices are sufficient to obtain the measurements needed for submission.
 \wl
 
 \noindent
@@ -705,7 +705,7 @@ Refer to Section~\ref{sec:MDSpecs} for the specifications of the required accura
 \subsection{Adjusting for Power Loss}
 \label{sec:AfPL}
 \noindent
-If the measurement device(s) that satisfy Aspect 1 are downstream of the ABC locations specified above, then two sets of measurements must be taken in order to determine the power loss between the required and the actual measurement location.
+If the measurement device(s) that satisfy Aspect~1 are downstream of the ABC locations specified above, then two sets of measurements must be taken in order to determine the power loss between the required and the actual measurement location.
 
 \begin{itemize}
 \item

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -282,7 +282,12 @@ All levels specify that power measurements be performed within the core phase of
 \subsection{Core Phase}
 \label{sec:core_phase}
 \noindent
-All submissions must include the average power within the core (parallel computation) phase of the run. 
+All submissions must include the average power within the core phase of the run. 
+\wl
+
+\noindent
+The core phase is usually considered to be the section of the workload that undergoes parallel execution. 
+It typically does not include the parallel job launch and teardown and is required to run for at least one minute.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -436,16 +436,21 @@ The higher machine fractions are required at the higher quality levels to reduce
 \wl
 
 \noindent
-The requirements for each quality level are as follows.
+The requirements with respect to the compute-node subsystem for each quality level are as follows.
 
 \begin{itemize}
 \item
-L1: $ \frac{1}{10} $ of the compute-node subsystem or 2 kW or 15 compute nodes, whichever is greater
+L1: $\frac{1}{10}$ of the compute-node subsystem or 2 kW or 15 compute nodes, whichever is greater
 \item
-L2: $ \frac{1}{8} $ of the compute-node subsystem or at least 10 kW or 15 compute nodes, whichever is greater
+L2: $\frac{1}{8}$ of the compute-node subsystem or at least 10 kW or 15 compute nodes, whichever is greater
 \item
 L3: the power use of the whole machine must be measured
 \end{itemize}
+
+\noindent
+For measurements of other subsystems (network, storage, etc.), measure at least $\frac{1}{10}$ for level 1, $\frac{1}{8}$ for level 2, and everything for level 3.
+
+
 
 \section{Aspect 3: Subsystems Included in Instrumented Power}
 \label{sec:A3SIiIP}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -449,6 +449,13 @@ L3: the power use of the whole machine must be measured
 
 \noindent
 For measurements of other subsystems (network, storage, etc.), measure at least $\frac{1}{10}$ for level 1, $\frac{1}{8}$ for level 2, and everything for level 3.
+\wl
+
+\noindent
+The fraction of a subsystem that is measured must be chosen such, that the entire subsystem is a real multiple of the fraction.
+For instance, a cluster consisting of blade servers with 8 nodes per chassis requires a measurement of entire chassis, hence a multiple of 8 nodes.
+Even if individual node power could be measured, that would not be valid as it would not include the common chassis.
+\wl
 
 
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -153,16 +153,20 @@ Equally spaced across the full run   \\
 
 \textbf{1c:~Measurements} &
 Core phase average power &
+$\bullet$ Core phase average power & 
+$\bullet$ Core phase total energy \\
+
+ & &
+$\bullet$ Full run average power &
+$\bullet$ Full run total energy \\
+
+ & &
 $\bullet$ 10 average power measurements in the core phase &
-$\bullet$  10 energy measurements in the core phase\\
+$\bullet$ 10 total energy measurements in the core phase \\
 
  & &
-$\bullet$  Full run average power &
-$\bullet$  Full run average power \\
-
- & &
-$\bullet$  idle power &
-$\bullet$  idle power \\
+$\bullet$ idle power &
+$\bullet$ idle power \\
 \hline
 
 \textbf{2: Machine \newline fraction}  &

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -121,7 +121,9 @@ Level 3 specifies a total energy measurement that, when divided by the measured 
 \wl
 
 \noindent
-Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed time between the initial and final energy readings in the core phase. The average power value for the core phase is the difference between the initial and final energy readings divided by the elapsed time.
+Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed time between the initial and final energy readings in the core phase.
+These last and first measurements in the core phase must be timed such that no more than a total of two seconds (one each at begin and end) of the core phase are not covered by the total energy measurement.
+The final average power value for the core phase is the difference between the initial and final energy readings divided by the elapsed time.
 
 \section{Aspect and Quality Levels}
 \label{sec:AQLevels}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -511,7 +511,7 @@ The total power measurement reported for compute nodes would then be
 The assumption of Levels 2 and 1 is that all the compute nodes in a set react identically to the workload.
 
 
-\section{Aspect 4: Point where the Electrical Measurements are Taken}
+\section{Aspect 4: Point where the Electrical Measurements are Taken and accuracy of power meter}
 \label{sec:A4wEMaT}
 Aspect 4 specifies where in the power distribution system the power delivery is measured.  For all quality levels, the submission indicates where power is measured and the quantity of parallel measurements points.
 \wl
@@ -556,6 +556,10 @@ At the entry point to the first power-modifying component (for example, the Blue
 
 \noindent
 If the measuring device or devices used to satisfy Aspect 1 also meet the ABC location requirements just specified above, then those devices are sufficient to obtain the measurements needed for submission.
+\wl
+
+\noindent
+Refer to Section~\ref{sec:MDSpecs} for the specifications of the required accuracy of the power meter devices.
 
 \subsection{Adjusting for Power Loss}
 \label{sec:AfPL}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -159,8 +159,8 @@ $\bullet$  idle power \\
 \hline
 
 \textbf{2: Machine \newline fraction}  &
-The greater of 1/10 of the compute subsystem or 2 kW  &
-The greater of 1/8 of the compute-node subsystem or 10 kW  &
+The greater of 1/10 of the compute subsystem or 2 kW or 15 compute nodes. Alternatively at least 40 kW. &
+The greater of 1/8 of the compute-node subsystem or 10 kW or 15 compute nodes &
 The whole of all included subsystems \\
 \hline
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -291,6 +291,8 @@ All submissions must include the average power within the core (parallel computa
 \noindent
 In order to correlate the power measurement and the performance measurement to obtain the power efficiency, power and performance must be measured over the exact same time period.
 Therefore, the core phase is defined as the time period that is used for the performance calculation.
+Sometimes, the exact same time is impossible to measure due to power meter restrictions.
+Therefore, level 1 and level allow a small part at the beginning and at the end which is not measured (see Section~\ref{sec:PAaTEM}).
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -147,7 +147,7 @@ For Levels 1 and 2, the units of the reported power values are watts.
 \subsubsection{Total Energy Measurements}
 
 \noindent
-Level 3 specifies a total energy measurement that, when divided by the measured time, also reports power. An integrated measurement is a continuing sum of energy measurements. Typically, there are hundreds of measurements per second.  Depending on the local frequency standard, there must be at least 120 or 100 measurements per second. The measuring device samples voltage and current many times per second and integrates those samples to determine the next total energy consumed reading. 
+Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power. An integrated measurement is a continuing sum of energy measurements. Typically, there are hundreds of measurements per second.  Depending on the local AC power line frequency, there must be at least 120 or 100 measurements per second. The measuring device samples voltage and current many times per second and integrate those samples to determine the next total energy consumed reading. 
 \wl
 
 \noindent
@@ -156,10 +156,6 @@ Level 3 reports an average power value for the core phase, an average power valu
 These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
 The final value for the full run must be obtained analogously.
-=======
-
-Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power. An integrated measurement is a continuing sum of energy measurements. Typically, there are hundreds of measurements per second.  Depending on the local AC power line frequency, there must be at least 120 or 100 measurements per second. The measuring device samples voltage and current many times per second and integrate those samples to determine the next total energy consumed reading. 
->>>>>>> Various clarifications
 \wl
 
 \noindent
@@ -210,8 +206,9 @@ $\bullet$ idle power \\
 \hline
 
 \textbf{2: Machine \newline fraction}  &
-The greater of 1/10 of the compute subsystem or 2 kW or 15 compute nodes. Alternatively at least 40 kW. &
-The greater of 1/8 of the compute-node subsystem or 10 kW or 15 compute nodes &
+<<<<<<< aeb65cd8bd3a9fbf4dbe4afeb92239ca0103e6c5
+The greater of 1/10 of the compute subsystem or 2~kW or 15~compute nodes. Alternatively at least 40~kW or the entire system. &
+The greater of 1/8 of the compute-node subsystem or 10~kW or 15~compute nodes &
 The whole of all included subsystems \\
 \hline
 
@@ -461,11 +458,11 @@ The requirements with respect to the compute-node subsystem for each quality lev
 
 \begin{itemize}
 \item
-L1: $\frac{1}{10}$ of the compute-node subsystem or 2 kW or 15 compute nodes, whichever is greater
+L1: $\frac{1}{10}$ of the compute-node subsystem or at least 2~kW or 15 compute nodes, whichever is greater. Alternatively, at least 40~kW or the entiry system.
 \item
-L2: $\frac{1}{8}$ of the compute-node subsystem or at least 10 kW or 15 compute nodes, whichever is greater
+L2: $\frac{1}{8}$ of the compute-node subsystem or at least 10~kW or 15 compute nodes, whichever is greater.
 \item
-L3: the power use of the whole machine must be measured
+L3: the power use of the whole machine must be measured.
 \end{itemize}
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -400,7 +400,7 @@ The measuring device must sample voltage and current, whether AC or DC, at least
 \wl
 
 \noindent
-The intervals at which total energy readings are reported must be short enough so that at least 10 reported readings fall within the core phase of the workload. Note that each reported reading is the average of many samples.
+The intervals at which total energy readings are reported must be short enough so that at least 10 reported readings fall within the core phase of the workload. Note that each reported energy reading is the integral over many internal power samples.
 \wl
 
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -71,15 +71,21 @@ Level~3 specifies an energy measurement, but reports a power value.
 \subsection{Sampling and Power Readings}
 \noindent
 For Levels 1 and 2, the power meter must internally sample the instantaneous power at a constant frequency of at least once per second.
-(Internally, one such power sample will usually require many more measurements of voltage and current taken much more frequently than once per second.
-The power meter will either integrate the measurements at a high frequency, or fit a sine wave curve to it and determine the power factor and in this way produce a power consumption reading.)
 Usually the net frequency varies by a small percentage around 50~Hz or 60~Hz.
 It is allowed that the measurement sample rate is not strictly constant, but it can be adjusted such that each sample interval covers a certain constant number of full sine waves.
 In that case, the intervals must not exceed one second by more than one sine wave and when building the final power average the power readings must be weighted by the duration of the sample interval.
 \wl
 
 \noindent
-Sampling in an AC context requires a measurement stage that determines the true power delivered at that point and enters that value into a buffer where it is then used to calculate average power over a longer time.
+\textit{(We do not specify exactly, how such a power sample must be measured in order to give the users greater flexibility in the choice of the power meter equipment.
+Usually, such a power sample, which is taken internally at least every second, will again consist of multiple measurements also internally.
+E.g.~the power meter will measure voltage and current much more frequently than once per second.
+It will either integrate their product, or fit sine waves to them, determine the power factor, and multiply the wave amplitutes with the factor.
+In this way, it generates one power sample.)}
+\wl
+
+\noindent
+Sampling in an AC context requires a measurement stage that determines the true power delivered at that point (denoted a power sample) and enters that value into a buffer where it is then used to calculate average power over a longer time.
 So ``sampled once per second'' in this context means that once per second a sample is added to the buffer used to calculate the average.
 Sampling delivered electrical power in a DC context refers to a single simultaneous measurement of the voltage and the current to determine the delivered power at that point.
 The sampling rate in this case is how often such a sample is taken and recorded internally within the device.
@@ -162,7 +168,7 @@ Level~3 specifies a total energy measurement that, when divided by the measured 
 An integrated measurement is a continuing sum of energy measurements.
 The measuring device samples voltage and current many times per second and integrates those samples to determine the next total energy consumed reading.
 Typically, there are hundreds of measurements per second.
-It is requested that the power meter samples at least at 120~Hz for a DC measurement and at least at~5kHz for an AC measurement.
+It is requested that the power meter samples voltage and current at least at 120~Hz for a DC measurement and at least at~5kHz for an AC measurement.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -2,14 +2,14 @@
 \label{sec:reporting}
 
 \noindent
-This section describes the information that must be included with a power measurement submission.
-It also describes some optional information that submitters may decide to include.
+This section contains:
+\begin{itemize}
+ \item The exact requirements for each quality level of each aspect.
+ \item A description what must be included with a power measurement submission.
+       It also describes some optional information that submitters may decide to include.
+ \item Definitions of the terms used to describe the elements of a power submission, some background information, motivation about why the list contains the elements it does, and any other details that may be helpful.
+\end{itemize}
 \wl
-
-\noindent
-The section contains definitions of the terms used to describe the elements of a power submission, some background information, motivation about why the list contains the elements it does, and any other details that may be helpful.
-\noindent
-
 
 \section{Measuring Device Specifications}
 \label{sec:MDSpecs}
@@ -20,7 +20,7 @@ This section defines meter accuracy requirements.
 \wl
 
 \noindent
-For Level~3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 1\% or better.
+For Level~3, it is required to use any revenue grade meter, any meter accepted by SPEC power, or any meter documented to have an accuracy of 1\% or better.
 Level~2 requires a meter with a minimum documented accuracy of 2\%.
 Level~1 requires a meter with a minimum documented accuracy of 5\%.
 \wl
@@ -53,7 +53,7 @@ In other words, you can use a single meter with 1\% accuracy, 4 meters with 2\% 
 
 \noindent
 Revenue grade meters are defined by ANSI C12.20.
-For meters accepted by the spec power, refer to the {\itshape Power and Temperature Measurement Setup Guide \/} and the list of accepted power measurement devices from the Standard Performance Evaluation Corporation.
+For meters accepted by the SPEC power, refer to the {\itshape Power and Temperature Measurement Setup Guide \/} and the list of accepted power measurement devices from the Standard Performance Evaluation Corporation.
 \begin{packed_item}
 \item 
 \url{http://www.spec.org/power_ssj2008/}
@@ -74,13 +74,13 @@ For Levels 1 and 2, the power meter must internally sample the instantaneous pow
 (Internally, one such power sample will usually require many more measurements of voltage and current taken much more frequently than once per second.
 The power meter will either integrate the measurements at a high frequency, or fit a sine wave curve to it and determine the power factor and in this way produce a power consumption reading.)
 Usually the net frequency varies by a small percentage around 50~Hz or 60~Hz.
-It is allowed that the measurement sample frequency is not strictly constant, but it can be adjusted such that each sample interval covers a certain number of full sine waves.
+It is allowed that the measurement sample rate is not strictly constant, but it can be adjusted such that each sample interval covers a certain constant number of full sine waves.
 In that case, the intervals must not exceed one second by more than one sine wave and when building the final power average the power readings must be weighted by the duration of the sample interval.
 \wl
 
 \noindent
 Sampling in an AC context requires a measurement stage that determines the true power delivered at that point and enters that value into a buffer where it is then used to calculate average power over a longer time.
-So ``sampled once per second'' in this context means that the times in the buffer are averaged and recorded once per second.
+So ``sampled once per second'' in this context means that once per second a sample is added to the buffer used to calculate the average.
 Sampling delivered electrical power in a DC context refers to a single simultaneous measurement of the voltage and the current to determine the delivered power at that point.
 The sampling rate in this case is how often such a sample is taken and recorded internally within the device.
 \wl
@@ -91,16 +91,16 @@ Refer to Section~\numnameref{sec:A3SIiIP} for details.
 \wl
 
 \noindent
-It is allowed that the power meter does not report every sample.
+It is allowed that the power meter does not report every power sample it takes.
 Instead, the power meter may use an internal buffer and aggregate several samples over time and then only report one average power reading at a certain constant frequency.
 In the following, we refer to such a reported power measurement of the power meter as ``power reading''.
 The intervals between the power readings must be no longer than 10\% of the duration of the core phase.
-If the power meter reports every sample, then a power sample and a power reading is the same.
+If the power meter reports every sample, then a power sample and a power reading are the same.
 \wl
 
 \noindent
 The power meter must use all power samples taken during an interval to compute the average power reading.
-Consider that the limits of one sample per second and one power reading per 10 seconds / 1 minute are upper bounds.
+Consider that the limits of one sample per second is an upper bound.
 Usually, the power meter will take many samples per second and report power readings on about a per second basis.
 
 \subsection{Power-Averaged and Total Energy Measurements}
@@ -114,8 +114,8 @@ This subsection describes the difference of power-averaged measurements as requi
 The reported power values for Levels~1 and~2 are power-averaged measurements over a certain time period (e.g.~the core phase or the full run).
 A power-averaged measurement is one taken by a device that samples the instantaneous power used by a system at some fine time resolution for a specified interval.
 This interval is short compared to the full time of the power-averaged measurement.
-The power meter device numerically averages of all the instantaneous power measurements sampled during that interval.
-This constitutes one measurement reported by the device covering that interval.
+The power meter device numerically averages of all the instantaneous power measurements samples during that interval.
+This constitutes one power reading reported by the device covering that interval.
 Finally, the power-averaged measurement for the required time period is the average of all these power readings obtained from the device in that period.
 All power readings reported by the device for that period must be used except for one case:
 Exclude those readings for intervals that do not lie completely in the requested time period.
@@ -129,8 +129,8 @@ In that case, the averaging process must weight the power readings from the powe
 
 \noindent
 Consider Level~1, which requires only one reported power value.
-This reported power value may consist of several power readings taken at a constant frequency of at least once per minute.
-Each such reading itself must be the average of instantaneous power samples measured at least once per second and averaged over reading interval.
+This reported power value may consist of several power readings taken at a constant frequency with interval length shorter than 10\% of the core phase.
+Each such reading itself must be the average of instantaneous power samples measured at least once per second and averaged over the reading interval.
 For Level~1, the time period that is measured must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
 For example, if the device reports one power measurement every 5 seconds (each being the average of at least 5 power samples) and the core phase takes 10 minutes, Level~1 reports one power-averaged value that averages over all the 120 measurements obtained during the core phase.
 (Usually the power reading intervals and the core phase are not synchronized, such that the first reding does not lie completely in the core phase.
@@ -138,11 +138,11 @@ In that case the average is only over the 119 readings completely in the core ph
 \wl
 
 \noindent
-Level~2 also requires that power measurements be taken at a constant frequency and the device must internally sample internally at least once per second.
-It requires the submission of the power-averaged measurement for the core phase, for the full run, and for a series of equally spaced power-averaged measurements of equal length during the full run.
-These power-averaged measurements in the series must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
-There must not be any delay between the power measurement in this series and they must cover the entire core phase.
-Alternatively, instead of the 10 power-averaged measurements, it is allowed to submit the full set of power readings from the device that are used to calculate the average power during the core phase and during the full run.
+Level~2 also requires that power readings be taken at a constant frequency and the device must internally sample internally at least once per second.
+It requires the submission of the power-averaged measurement for the core phase (as Level~1 does), for the full run, and for a series of power-averaged measurements of equal length at regular intervals during the full run.
+The measurement interval must be short enough so that at least 10 measurements are reported during the core phase of the workload.
+There must be no gap between these regular measurements, i.e. this series of measurements in total must cover the full run.
+Alternatively, instead of this series of power-averaged measurements, it is allowed to submit the full set of power readings from the device that are used to calculate the average power during the core phase and during the full run.
 \wl
 
 \noindent
@@ -160,13 +160,13 @@ For Levels~1 and~2, the units of the reported power values are watts.
 \noindent
 Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power.
 An integrated measurement is a continuing sum of energy measurements.
-The measuring device samples voltage and current many times per second and integrate those samples to determine the next total energy consumed reading.
+The measuring device samples voltage and current many times per second and integrates those samples to determine the next total energy consumed reading.
 Typically, there are hundreds of measurements per second.
 It is requested that the power meter samples at least at 120~Hz for a DC measurement and at least at~5kHz for an AC measurement.
 \wl
 
 \noindent
-Level~3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
+Level~3 reports an average power value for the core phase, an average power value for the whole run, at least 10 energy values at regular intervals within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
 These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
 The final value for the full run must be obtained analogously.
@@ -222,7 +222,7 @@ $\bullet$ idle power \\
 
 \textbf{2: Machine \newline fraction}  &
 The greater of $\frac{1}{10}$ of the compute subsystem or 2~kW or 15~compute nodes - alternatively at least 40~kW or the entire system &
-The greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW or 15~compute nodes &
+The greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW or 15~compute nodes - alternatively the entire system &
 The whole of all included subsystems \\
 \hline
 
@@ -386,37 +386,39 @@ L3 requires an integrating total-energy meter, which samples the input power mul
 
 \subsection{Level~1}
 \noindent
+Level~1 submissions include a measurement of the average power during the core phase.
 The device measurement granularity must be at least one instantaneous measurement of power per second.
 This requirement holds whether the measurement is DC or AC.
 \wl
 
 \noindent
 There must be at least one power-averaged measurement during the run.
-The total interval covered must be the core phase of the run which must be at
-least one minute long.
+The total interval covered must be the core phase of the run which must be at least one minute long.
+Exclude power readings for time intervals that do not lie completely in the core phase.
 \wl
 
 \subsection{Level~2}
 \noindent
-Level~2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run.
-The workload run must have a series of power-averaged measurements at constant time intervals.
-These measurement intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload.
-The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.
+Level~2 submissions include a measurement of the average power during the core phase of the run, the average power during the full run, and a series of regular power-averaged measurements.
+The device measurement granularity must be at least one instantaneous measurement of power per second.
+This requirement holds whether the measurement is DC or AC.
 \wl
 
 \noindent
-The complete set of power-averaged measurements used to calculate average power must also be provided.
-The device measurement sampling granularity must be at least one instantaneous measurement of power per second.
+The submitted value for the core phase must be the average of all power readings taken during the core phase of the run.
+In addition, the average of all power readings during the full run must be submitted.
+In both cases, exclude power readings for time intervals that do not lie completely in the respective time period of core phase and full run.
+The core phase is required to run for at least one minute.
 \wl
 
 \noindent
-There is some unspecified number of power-averaged measurements during the workload but outside of the core phase.
-The reported average power for the whole run will be the numerical average of the power measurements for the whole run.
+On top of these full measurements, a series of power-averaged measurements of equal length at regular intervals must be submitted for the full run.
+These intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload.
+There must be no gap between these regular measurements, i.e. this series of measurements in total must cover the full run.
 \wl
 
-
 \noindent
-Figure~\ref{fig:a1l2pm} illustrates Aspect~1 of a Level~2 power measurement.
+Figure~\ref{fig:a1l2pm} illustrates the series of power measurements at regular intervals of Aspect~1 of a Level~2 power measurement.
 Each measurement is an average of instantaneous power measurements, and these instantaneous measurements are taken once per second.
 As an example, the figure shows 10 power-averaged measurements within the core phase and four power-averaged measurements outside the core phase, two before the core phase and two after the core phase.
 
@@ -453,6 +455,12 @@ The intervals at which total energy readings are reported must be short enough s
 Note that each reported energy reading is the integral over many internal power samples.
 \wl
 
+\noindent
+The measured energy for the core phase is the last measured total energy within the core phase minus the first measured total energy within the core phase.
+The final power is calculated by dividing this energy by the elapsed time between these first and last energy readings.
+These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
+The procedure for the full run is analogous.
+\wl
 
 \noindent
 Figure~\ref{fig:a1l3pm} illustrates Aspect~1 of  Level~3 power measurement.
@@ -520,8 +528,9 @@ L1: The largest of $\frac{1}{10}$ of the compute-node subsystem or at least 2~kW
 Alternatively, at least 40~kW or the entiry system.
 \item
 L2: The largest of $\frac{1}{8}$ of the compute-node subsystem or at least 10~kW or 15 compute nodes.
+Alternatively, the entire system if smaller than 15 nodes.
 \item
-L3: the power use of the whole machine must be measured.
+L3: The power use of the whole machine must be measured.
 \end{itemize}
 
 \noindent
@@ -535,18 +544,18 @@ Even if individual node power could be measured, that would not be valid as it w
 \wl
 
 \noindent
-The requirement for Level~1 and Level~2 include the measurement of at least 15 nodes.
+The requirements for Level~1 and Level~2 include the measurement of at least 15 nodes.
 For a cluster consisting of individual servers, a node is simply defined as one server.
 There are architectures with multiple individual servers in one chassis, e.g.
 2U twin or twin$^2$ servers with 2 and 4 servers per chassis and blade servers with many more nodes in one chassis.
 Usually, all the nodes in one chassis share redundant power supplies.
-In that case, you have to measure entire chassis, including all the power supplies of a chassis.
+Hence, in that case you have to measure entire chassis, including all the power supplies of a chassis.
 The measurement of a chassis is then considered a measurement of as many nodes as there are nodes in the chassis.
 \wl
 
 \noindent
 For a measurement of only a fraction of a subsystem, this fraction must be chosen randomly.
-In this context, random refers to the entity that are measured.
+In this context, random refers to the entity that is measured.
 For instance, if you measure nodes then choose random nodes, if you measure entire racks, choose random racks.
 It is not allowed to screen the system for components with lower power consumtion and then measure only that fraction nor is it allowed to replace components in the chosen fraction by ones with lower power consumption.
 \wl
@@ -567,23 +576,19 @@ Subsystems include computational nodes, any interconnect network the application
 \wl
 
 \noindent
-If some subsystems are part of the measured power, their power may not be subtracted out after the fact.
+If some subsystems are part of the measured power, their power may not be subtracted out after the measurement.
 The explicitly measured value must be used as is.
 \wl
-
 
 \noindent
 For Level~1, both the compute-node subsystem and the interconnect must be reported.
 The compute-node subsystem power must be measured.
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem.
-This may include infrastructure that is shared, but excludes parts that are not servicing the system under test.
-For some systems, it may be impossible not to include a power contribution from some subsystems.
-In this case, provide a list of the measured subsystems, but do not subtract an estimated value for the included subsystem.
 \wl
 
 \noindent
-For Level~2, include the compute node subsystem.
+For Level~2, measure the compute node subsystem.
 Other subsystems participating in the workload must be measured or estimated.
 \wl
 
@@ -593,20 +598,17 @@ The reported power measurement must include all computational nodes, any interco
 \wl
 
 \noindent
-For Levels~1 and~2, estimations of other subsystems besides the compute subsystem must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
+For Levels~1 and~2, estimations of other subsystems besides the compute subsystem must be performed by substituting the measurement by an upper bound derived from the maximum specified power consumption of all hardware components.
 \wl
 
 \noindent
-For Levels~2 and~3, the reported power measurement may exclude storage subsystems that don't participate in the workload.
-It is not required to exclude such storage subsystems.
-However, if these storage subsystems are part of the cabinet or rack being measured, they may not be excluded even if they are not used.
+Measurements may include infrastructure that is shared.
+It is allowed but not required to exclude subsystems that don't participate in the workload (e.g. storage subsystems).
+However, if these subsystems are part of the cabinet or rack being measured, they may not be excluded even if they are not used.
 That is, the submitter cannot calculate their contribution and subtract that contribution.
-If the storage subsystem is not part of the rack or cabinet being measured and it does not participate in the workload, it need not be measured.
-\wl
-
-\noindent
-In some cases, the submitter may be measuring power that the application doesn't actually use.
-If the submitter can exclude the unused subsystems from the measurement or easily turn off the power to the unused subsystems, then the submitter can choose not to include those subsystems in the measurement.
+If the subsystem is not part of the rack or cabinet being measured and it does not participate in the workload, it need not be measured.
+For some systems, it may be impossible not to include a power contribution from certain subsystems that are not used by the application.
+In this case, provide a list of the measured subsystems, but do not subtract an estimated value for the subsystems that are not used.
 \wl
 
 \noindent
@@ -620,9 +622,18 @@ A site may include more subsystems than are strictly required if it chooses or i
 \wl
 
 \noindent
+In other words, for Level~2 and~3 you have to include everything that you cannot turn of during the benchmark run.
+It only allowed to exclude subsystems (or parts thereof) from the measurement in the first place, but their contribution must not be subtracted afterwards.
+For Level~1 this applies as well, but only for the network subsystem.
+\wl
+
+\subsection{Hererogeneous Systems}
+
+\noindent
 A particular system may have different types of compute nodes.
 The system may have compute nodes from different companies or even compute nodes with different architectures.
 These compute nodes are said to belong to different heterogeneous sets.
+Each heterogeneous set must consist of identical nodes.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -505,16 +505,17 @@ In this case, provide a list of the measured subsystems, but do not subtract an 
 \wl
 
 \noindent
-For Level 2,  include the compute node subsystem. Other subsystems participating in the workload must be measured or estimated. The estimations must be based on derived numbers from the equipment manufacturer's specifications. 
+For Level 2, include the compute node subsystem.
+Other subsystems participating in the workload must be measured or estimated.
 \wl
-
 
 \noindent
 For Level 3, all power going to the parts of a computer system that participate in a workload must be included in the power measurement. 
+The reported power measurement must include all computational nodes, any interconnect network the application uses, any head or control nodes, any storage system the application uses, all power conversion losses inside the computer, and any internal cooling devices (self-contained liquid cooling systems and fans).  
 \wl
 
 \noindent
-For Level 3, the reported power measurement must include all computational nodes, any interconnect network the application uses, any head or control nodes, any storage system the application uses, all power conversion losses inside the computer, and any internal cooling devices (self-contained liquid cooling systems and fans).  
+For Levels 1 and 2, estimations of other subsystems besides the compute subsystem must be performed by substituting the measurement by an uppower bound derived from the maximum specified power consumption of all hardware components.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -468,6 +468,13 @@ In that case, you have to measure entire chassis, including all the power suppli
 The measurement of a chassis is then considered a measurement of as many nodes as there are nodes in the chassis.
 \wl
 
+\noindent
+For a measurement of only a fraction of a subsystem, this fraction must be chosen randomly.
+In this context, random refers to the entity that are measured.
+For instance, if you measure nodes then choose random nodes, if you measure entire racks, choose random racks.
+It is not allowed to screen the system for components with lower power consumtion and then measure only that fraction nor is it allowed to replace components in the chosen fraction by ones with lower power consumption.
+\wl
+
 \section{Aspect 3: Subsystems Included in Instrumented Power}
 \label{sec:A3SIiIP}
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -77,7 +77,7 @@ Sampling delivered electrical power in a DC context refers to a single simultane
 
 \noindent
 If the submitter is sampling in a DC context, most likely it will be necessary to adjust for power loss in the AC/DC conversion stage. 
-Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented Power for details.
+Refer to Section~\numnameref{sec:A3SIiIP} for details.
 \wl
 
 \noindent
@@ -89,7 +89,6 @@ If the power meter reports every sample, then a power sample and a power reading
 \wl
 
 \noindent
-<<<<<<< 6eeac015b98513fb43fe8cfe1f2adf00ae545965
 The power meter must use all power samples taken during an interval to compute the average power reading.
 Consider that the limits of one sample per second and one power reading per 10 seconds / 1 minute are upper bounds.
 Usually, the power meter will take many samples per second and report power readings on about a per second basis.
@@ -593,7 +592,7 @@ All the reported measurements taken in parallel at a given instant in time are t
 
 \noindent
 AC measurements are upstream of the system's power conversion. If the measurements are in a DC context, the submitter may have to take into account some power loss. 
-Refer to Section~\ref{sec:AfPL} Adjusting for Power Loss.
+Refer to Section~\numnameref{sec:AfPL}.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -73,7 +73,7 @@ A power-averaged measurement is one taken by a device that samples the instantan
 The power-averaged measurement for the interval is the numerical average of all the instantaneous power measurements during that interval and constitutes one reported measurement covering that interval. 
 We require that the sampling frequncy must be at least 1 Hz and constant.
 As noted in the previous subsection, the frequency may vary slightly to accomodate for variations in the net frequency.
-In that case, the sample must be weighted according to the sample intervals.
+In that case, the samples must be weighted according to the sample intervals.
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -218,7 +218,7 @@ Compute-nodes measured, all participating subsystems measured or estimated &
 All participating subsystem must be measured \\
 \hline
 
-\textbf{4a: Point of measurement} &
+\textbf{4: Location of measurement} &
 Upstream of power conversion &
 Upstream of power conversion &
 Upstream of power conversion\\
@@ -256,21 +256,22 @@ The reported measurements. This aspect describes how the power measurements are 
 \end{itemize}
 
 \noindent
-For all required measurements, the submission must also include the data used to calculate them. For Level 2 and Level 3 submissions, the supporting data must include at least 10 equally spaced points in the core of the run. 
+For all required measurements, the submission must also include the data used to calculate them. For Level 2 and Level 3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core of the run. 
 \wl
 
 \noindent
-Levels 2 and 3 require a number of equally spaced measurements to be reported for two reasons.  
+Levels 2 and 3 require reported measurement values at regular intervals for the following reasons:
 
 \begin{itemize}
 \item
-One is that facility or infrastructure level power measurements are typically taken by a system separate from the system OS and thus cannot be easily synchronized with running the benchmark.  
+Facility or infrastructure level power measurements are typically taken by a system separate from the system OS and thus cannot be easily synchronized with running the benchmark.
 \item
-Secondly, with multiple periodic measurements, more reporting points are included before and after the benchmark run to ensure that a uniform standard of "beginning" and "end" of the power measurement can be applied to all the power measurements on a list.  
+With multiple periodic measurements, more measurement values are included before and after the benchmark run.
+This ensures that a uniform standard of \textit{beginning} and \textit{end} of the power measurement can be applied to all the power measurements from different sensors.
 \end{itemize}
 
 \noindent
-There is no maximum number of reported points, although one reported measurement per second is probably a reasonable upper limit. The submitter may choose to include more than 10 such points.
+There is no maximum number of reported measurement values, although one reported measurement per second is a reasonable upper limit. The submitter may choose to include more than 10 such measurement values.
 \wl
 
 \noindent
@@ -578,13 +579,13 @@ The total power measurement reported for compute nodes would then be
 The assumption of Levels 2 and 1 is that all the compute nodes in a set react identically to the workload.
 
 
-\section{Aspect 4: Point where the Electrical Measurements are Taken and accuracy of power meter}
+\section{Aspect 4: Instrumentation Location where the Electrical Measurements are Taken}
 \label{sec:A4wEMaT}
-Aspect 4 specifies where in the power distribution system the power delivery is measured.  For all quality levels, the submission indicates where power is measured and the quantity of parallel measurements points.
+Aspect 4 specifies where in the power distribution system the power delivery is measured.  For all quality levels, the submission indicates where power is measured and the quantity of parallel measurements.
 \wl
 
 \noindent
-Measurements of power or energy are typically made at multiple points in parallel across the computer system. For example, such locations can be at the entrance to each separate rack, or at the exit points of multiple building transformers. 
+Measurements of power or energy are typically made at multiple locations in parallel across the computer system. For example, such locations can be at the entrance to each separate rack, or at the output connector of multiple building transformers. 
 \wl
 
 \noindent
@@ -601,23 +602,23 @@ Electrical power or energy measurements shall be taken in one of the following l
 
 \begin{itemize}
 \item[{A)}]
-At a point upstream of where the electrical supply from the data center is delivered to the computer system
+At a location upstream of where the electrical supply from the data center is delivered to the computer system
 
 OR
 
 \item[{B)}]
-At the point of the electrical supply delivery to the computer system from the data center
+At the location of the electrical supply delivery to the computer system from the data center
 
 OR
 
 \item[{C)}]
-At a point just inside of the computer system that is electrically equivalent to location B) above.  This includes the following. 
+At a location just inside of the computer system that is electrically equivalent to location B) above.  This includes the following. 
 
 \begin{itemize}
 \item
-At any point within a passive PDU, at the input to the PDU, at the exit point(s) of the PDU, or anywhere in between 
+At any location within a passive PDU, at the input to the PDU, at the output connector(s) of the PDU, or anywhere in between 
 \item
-At the entry point to the first power-modifying component (for example, the Blue Gene bulk power module, Cray AC/DC converters, and possibly the input point to one or more crate power supplies)
+At the input connector to the first power-modifying component (for example, the Blue Gene bulk power module, Cray AC/DC converters, and possibly the input connector to one or more crate power supplies)
 \end{itemize}
 \end{itemize}
 
@@ -639,7 +640,7 @@ For a Level 1 measurement, the power loss may be a load-varying model based on s
 \item
 For a Level 2 measurement, the power loss may be a load-varying model based on an actual physical measurement of one power supply in the system.  
 \item
-For a Level 3 submission, the power loss must be measured simultaneously by a device at the required point (one of the ABC locations) measured at least once every five minutes, averaged long enough to average out the AC transients. 
+For a Level 3 submission, the power loss must be measured simultaneously by a device at the required location (one of the ABC locations) measured at least once every five minutes, averaged long enough to average out the AC transients. 
 \end{itemize}
 
 \noindent
@@ -647,7 +648,7 @@ For all three levels, the power losses used and how they were determined must be
 
 \subsection{Data Center Schematic}
 \noindent
-Figure~\ref{fig:powmeasschem} is an example of a simple power measurement schematic. This example shows only one power measurement point.
+Figure~\ref{fig:powmeasschem} is an example of a simple power measurement schematic. This example shows only one power measurement location.
 \wl
 
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -2,10 +2,6 @@
 \label{sec:reporting}
 
 \noindent
-Refer to this section for detailed information about the elements of a power submission. 
-\wl
-
-\noindent
 This section describes the information that must be included with a power measurement submission. It also describes some optional information that submitters may decide to include.
 \wl
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -18,9 +18,9 @@ Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}. This section defines meter acc
 \wl
 
 \noindent
-For Level 3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 1\% or better. 
-Level 2 requires a meter with a minimum documented accuracy of 2\%.
-Level 1 requires a meter with a minimum documented accuracy of 5\%.
+For Level~3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 1\% or better. 
+Level~2 requires a meter with a minimum documented accuracy of 2\%.
+Level~1 requires a meter with a minimum documented accuracy of 5\%.
 \wl
 
 \noindent
@@ -31,17 +31,17 @@ It is acceptable if the error is documented either as a hard bound, as the 1$\si
 \wl
 
 \noindent
-If the site uses multiple independent power meters for a level 2 or a level 3 measurement, and if all employed power meters measure an identical fraction of the system, the requirements are relaxed in the following way.
+If the site uses multiple independent power meters for a Level~2 or a Level~3 measurement, and if all employed power meters measure an identical fraction of the system, the requirements are relaxed in the following way.
 \begin{packed_item}
 \item 
 Each individual power meter must have at least a documented accuracy of 3\%.
 \item
-The documented error of the individual meters divided by the square root of the number of employed meters must meet the above requirements of 2\% for level 2 and 1\% for level 1.
+The documented error of the individual meters divided by the square root of the number of employed meters must meet the above requirements of 2\% for Level~2 and 1\% for Level~1.
 \end{packed_item}
 In this case, the second requirement ensures that the standard deviation of the measurement of the entire run, using error propagation, and assuming a gaussian distribution, and assuming that the errors of the power meters are uncorelated, meets the requirements.
-For example, assume 4 power meters for a level 3 measurement, each measuring 25\% of the total system.
+For example, assume 4 power meters for a Level~3 measurement, each measuring 25\% of the total system.
 In that case, each meter must have a documented accuracy of~$1\% \cdot \sqrt{4} = 2\%$.
-In other words, you can use a single meter with 1\% accuracy, 4 meters with 2\% accuracy, or 9 meters with 3\% accuracy for level 3.
+In other words, you can use a single meter with 1\% accuracy, 4 meters with 2\% accuracy, or 9 meters with 3\% accuracy for Level~3.
 \wl
 
 \noindent
@@ -58,7 +58,7 @@ For meters accepted by the spec power, refer to the {\itshape Power and Temperat
 \section{Measuring Device Terminology}
 \label{sec:MDTerm}
 \noindent
-Levels 1 and 2 specify power measurements. Level 3 specifies an energy measurement, but reports a power value.
+Levels 1 and 2 specify power measurements. Level~3 specifies an energy measurement, but reports a power value.
 
 \subsection{Sampling and Power Readings}
 \noindent
@@ -97,7 +97,7 @@ Usually, the power meter will take many samples per second and report power read
 \subsection{Power-Averaged and Total Energy Measurements}
 \label{sec:PAaTEM}
 
-This subsection describes the difference of power-averaged measurements as required for level 1 and level 2 as compared to total energy measurements as required for level 3.
+This subsection describes the difference of power-averaged measurements as required for Level~1 and Level~2 as compared to total energy measurements as required for Level~3.
 
 \subsubsection{Power-Averaged Measurements}
 
@@ -119,16 +119,16 @@ In that case, the averaging process must weight the power readings from the powe
 \wl
 
 \noindent
-Consider Level 1, which requires only one reported power value. 
+Consider Level~1, which requires only one reported power value. 
 This reported power value may consist of several power readings taken at a constant frequency of at least once per minute.
 Each such reading itself must be the average of instantaneous power samples measured at least once per second and averaged over reading interval.
-For Level 1, the time period that is measured must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
-For example, if the device reports one power measurement every 5 seconds (each being the average of at least 5 power samples) and the core phase takes 10 minutes, Level 1 reports one power-averaged value that averages over all the 120 measurements obtained during the core phase.
+For Level~1, the time period that is measured must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
+For example, if the device reports one power measurement every 5 seconds (each being the average of at least 5 power samples) and the core phase takes 10 minutes, Level~1 reports one power-averaged value that averages over all the 120 measurements obtained during the core phase.
 (Usually the power reading intervals and the core phase are not synchronized, such that the first reding does not lie completely in the core phase. In that case the average is only over the 119 readings completely in the core phase.)
 \wl
 
 \noindent
-Level 2 also requires that power measurements be taken at a constant frequency and the device must internally sample internally at least once per second.
+Level~2 also requires that power measurements be taken at a constant frequency and the device must internally sample internally at least once per second.
 It requires the submission of the power-averaged measurement for the core phase, for the full run, and for a series of equally spaced power-averaged measurements of equal length during the full run.
 These power-averaged measurements in the series must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
 There must not be any delay between the power measurement in this series and they must cover the entire core phase.
@@ -136,7 +136,7 @@ Alternatively, instead of the 10 power-averaged measurements, it is allowed to s
 \wl
 
 \noindent
-The measurement for the core phase for Level 2 is identical to the measurement in Level 1.
+The measurement for the core phase for Level~2 is identical to the measurement in Level~1.
 Assume again one measurement every 5 seconds (consisting of 5 samples each), a core phase of 10 minutes and a full run of 15 minutes.
 In that case, the submission includes one power-averaged measurement over 120 power readings for the core phase, one power-averaged measurement over 180 readings for the full run, and for instance a series of 30 power-averaged measurements over 6 power readings each, once every 30 seconds.
 \wl
@@ -152,7 +152,7 @@ Level~3 specifies a total energy measurement that, when divided by the measured 
 \wl
 
 \noindent
-Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
+Level~3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
 These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
 The final value for the full run must be obtained analogously.
@@ -172,7 +172,7 @@ Table~\ref{tab:levels} summarizes the aspect and quality levels introduced in Se
 \caption{Summary of aspects and quality levels}
 \label{tab:levels}
 \begin{tabular}{|p{3.0cm}|p{3.5cm}|p{3.5cm}|p{3.5cm}|} \hline
-\textbf{Aspect}&\textbf{Level 1}&\textbf{Level 2}&\textbf{Level 3}\\ \hline
+\textbf{Aspect}&\textbf{Level~1}&\textbf{Level~2}&\textbf{Level~3}\\ \hline
 
 \textbf{1a:~Granularity} &
 One power sample per second &
@@ -255,7 +255,7 @@ The reported measurements. This aspect describes how the power measurements are 
 \end{itemize}
 
 \noindent
-For all required measurements, the submission must also include the data used to calculate them. For Level 2 and Level 3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core of the run. 
+For all required measurements, the submission must also include the data used to calculate them. For Level~2 and Level~3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core of the run. 
 \wl
 
 \noindent
@@ -290,7 +290,7 @@ All submissions must include the average power within the core (parallel computa
 In order to correlate the power measurement and the performance measurement to obtain the power efficiency, power and performance must be measured over the exact same time period.
 Therefore, the core phase is defined as the time period that is used for the performance calculation.
 Sometimes, the exact same time is impossible to measure due to power meter restrictions.
-Therefore, level 1 and level allow a small part at the beginning and at the end which is not measured (see Section~\ref{sec:PAaTEM}).
+Therefore, Level~1 and Level~2 allow a small part at the beginning and at the end which is not measured (see Section~\ref{sec:PAaTEM}).
 \wl
 
 \noindent
@@ -305,7 +305,7 @@ HPL\_pdgesv() end time Wed Jun 30 22:23:15 2015
 
 \subsection{The Whole Run}
 \noindent
-Level 2 and Level 3 submissions must also include the average power for the whole run, from the initiation of the job to its completion. 
+Level~2 and Level~3 submissions must also include the average power for the whole run, from the initiation of the job to its completion. 
 \wl
 
 \noindent
@@ -346,7 +346,7 @@ L3 requires a power-meter device with a higher inherent measurement granularity 
 L1 / L2 allow 1-second intervals of the input power.
 L3 requires an integrating total-energy meter, which samples the input power multiple times per AC cycle and so is much less susceptible to sampling artifacts caused by the AC waveform.  
 
-\subsection{Level 1}
+\subsection{Level~1}
 \noindent
 The device measurement granularity must be at least one instantaneous measurement of power per second. This requirement holds whether the measurement is DC or AC.
 \wl
@@ -357,9 +357,9 @@ The total interval covered must be the core phase of the run which must be at
 least one minute long.
 \wl
 
-\subsection{Level 2}
+\subsection{Level~2}
 \noindent
-Level 2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run. The workload run must have a series of power-averaged measurements at constant time intervals. These measurement intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload. The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.  
+Level~2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run. The workload run must have a series of power-averaged measurements at constant time intervals. These measurement intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload. The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.  
 \wl
 
 \noindent
@@ -373,19 +373,19 @@ There is some unspecified number of power-averaged measurements during the workl
 
 
 \noindent
-Figure~\ref{fig:a1l2pm} illustrates Aspect 1 Level 2 power measurement. Each measurement is an average of instantaneous power measurements, and these instantaneous measurements are taken once per second. As an example, the figure shows 10 power-averaged measurements within the core phase and four power-averaged measurements outside the core phase, two before the core phase and two after the core phase.
+Figure~\ref{fig:a1l2pm} illustrates Aspect~1 of a Level~2 power measurement. Each measurement is an average of instantaneous power measurements, and these instantaneous measurements are taken once per second. As an example, the figure shows 10 power-averaged measurements within the core phase and four power-averaged measurements outside the core phase, two before the core phase and two after the core phase.
 
 %INCLUDE FIG 3-4
 \begin{figure}
 \centering
 \includegraphics[width=4in]{fig3-4}
-\caption{Aspect 1 Level 2 Power Measurements}
+\caption{Aspect~1 of Level~2 Power Measurements}
 \label{fig:a1l2pm}
 \end{figure}
 
-\subsection{Level 3}
+\subsection{Level~3}
 \noindent
-Level 3 submissions include a measurement of the average power during the core phase of the run and the average power during the full run.
+Level~3 submissions include a measurement of the average power during the core phase of the run and the average power during the full run.
 \wl
 
 \noindent
@@ -393,7 +393,7 @@ The complete set of total energy readings (at least 10 during the core computati
 \wl
 
 \noindent
-Level 3 requires continuously integrated total energy measurements rather than power-averaged measurements. The readings must begin before the start of the run and extend to when it is finished.
+Level~3 requires continuously integrated total energy measurements rather than power-averaged measurements. The readings must begin before the start of the run and extend to when it is finished.
 \wl
 
 \noindent
@@ -406,13 +406,13 @@ The intervals at which total energy readings are reported must be short enough s
 
 
 \noindent
-Figure~\ref{fig:a1l3pm} illustrates Aspect 1 Level 3 power measurement. The figure shows 10 readings in the core phase of the workload. Note that these are integrated readings.  To obtain a power reading, one must subtract two integrated readings and divide by the time between the readings.
+Figure~\ref{fig:a1l3pm} illustrates Aspect~1 of  Level~3 power measurement. The figure shows 10 readings in the core phase of the workload. Note that these are integrated readings.  To obtain a power reading, one must subtract two integrated readings and divide by the time between the readings.
 
 %INCLUDE FIG 3-5
 \begin{figure}
 \centering
 \includegraphics[width=4in]{fig3-5}
-\caption{Aspect 1 Level 3 Power Measurements}
+\caption{Aspect~1 of Level~3 Power Measurements}
 \label{fig:a1l3pm}
 \end{figure}
 
@@ -438,11 +438,11 @@ The submitter may find it useful to create a graph showing the power and energy 
 \section{Aspect 2: Machine Fraction Instrumented}
 \label{sec:A2MFI}
 \noindent
-Aspect 2 specifies the fraction of the system whose power feeds are instrumented by the measuring equipment. 
+Aspect~2 specifies the fraction of the system whose power feeds are instrumented by the measuring equipment. 
 \wl
 
 \noindent
-Level 3 requires that the entire machine be measured. Level 2 requires a higher fraction than Level 1.
+Level~3 requires that the entire machine be measured. Level~2 requires a higher fraction than Level~1.
 \wl
 
 \noindent
@@ -466,7 +466,7 @@ L3: the power use of the whole machine must be measured.
 \end{itemize}
 
 \noindent
-For measurements of other subsystems (network, storage, etc.), measure at least $\frac{1}{10}$ for level 1, $\frac{1}{8}$ for level 2, and everything for level 3.
+For measurements of other subsystems (network, storage, etc.), measure at least $\frac{1}{10}$ for Level~1, $\frac{1}{8}$ for Level~2, and everything for Level~3.
 \wl
 
 \noindent
@@ -476,7 +476,7 @@ Even if individual node power could be measured, that would not be valid as it w
 \wl
 
 \noindent
-The requirement for level 1 and level 2 include the measurement of at least 15 nodes.
+The requirement for Level~1 and Level~2 include the measurement of at least 15 nodes.
 For a cluster consisting of individual servers, a node is simply defined as one server.
 There are architectures with multiple individual servers in one chassis, e.g. 2U twin or twin$^2$ servers with 2 and 4 servers per chassis and blade servers with many more nodes in one chassis.
 Usually, all the nodes in one chassis share redundant power supplies.
@@ -511,7 +511,7 @@ If some subsystems are part of the measured power, their power may not be subtra
 
 
 \noindent
-For Level 1, both the compute-node subsystem and the interconnect must be reported.  
+For Level~1, both the compute-node subsystem and the interconnect must be reported.  
 The compute-node subsystem power must be measured. 
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
 Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
@@ -521,12 +521,12 @@ In this case, provide a list of the measured subsystems, but do not subtract an 
 \wl
 
 \noindent
-For Level 2, include the compute node subsystem.
+For Level~2, include the compute node subsystem.
 Other subsystems participating in the workload must be measured or estimated.
 \wl
 
 \noindent
-For Level 3, all power going to the parts of a computer system that participate in a workload must be included in the power measurement. 
+For Level~3, all power going to the parts of a computer system that participate in a workload must be included in the power measurement. 
 The reported power measurement must include all computational nodes, any interconnect network the application uses, any head or control nodes, any storage system the application uses, all power conversion losses inside the computer, and any internal cooling devices (self-contained liquid cooling systems and fans).  
 \wl
 
@@ -555,7 +555,7 @@ A particular system may have different types of compute nodes. The system may ha
 \wl
 
 \noindent
-With Level 3, the submitter need not be concerned about heterogeneous sets of compute nodes because Level 3 measures the entire system. 
+With Level~3, the submitter need not be concerned about heterogeneous sets of compute nodes because Level~3 measures the entire system. 
 \wl
 
 \noindent
@@ -635,11 +635,11 @@ If the measurement device(s) that satisfy Aspect 1 are downstream of the ABC loc
 
 \begin{itemize}
 \item
-For a Level 1 measurement, the power loss may be a load-varying model based on specifications from the manufacturer.  
+For a Level~1 measurement, the power loss may be a load-varying model based on specifications from the manufacturer.  
 \item
-For a Level 2 measurement, the power loss may be a load-varying model based on an actual physical measurement of one power supply in the system.  
+For a Level~2 measurement, the power loss may be a load-varying model based on an actual physical measurement of one power supply in the system.  
 \item
-For a Level 3 submission, the power loss must be measured simultaneously by a device at the required location (one of the ABC locations) measured at least once every five minutes, averaged long enough to average out the AC transients. 
+For a Level~3 submission, the power loss must be measured simultaneously by a device at the required location (one of the ABC locations) measured at least once every five minutes, averaged long enough to average out the AC transients. 
 \end{itemize}
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -459,7 +459,14 @@ For instance, a cluster consisting of blade servers with 8 nodes per chassis req
 Even if individual node power could be measured, that would not be valid as it would not include the common chassis.
 \wl
 
-
+\noindent
+The requirement for level 1 and level 2 include the measurement of at least 15 nodes.
+For a cluster consisting of individual servers, a node is simply defined as one server.
+There are architectures with multiple individual servers in one chassis, e.g. 2U twin or twin$^2$ servers with 2 and 4 servers per chassis and blade servers with many more nodes in one chassis.
+Usually, all the nodes in one chassis share redundant power supplies.
+In that case, you have to measure entire chassis, including all the power supplies of a chassis.
+The measurement of a chassis is then considered a measurement of as many nodes as there are nodes in the chassis.
+\wl
 
 \section{Aspect 3: Subsystems Included in Instrumented Power}
 \label{sec:A3SIiIP}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -2,7 +2,8 @@
 \label{sec:reporting}
 
 \noindent
-This section describes the information that must be included with a power measurement submission. It also describes some optional information that submitters may decide to include.
+This section describes the information that must be included with a power measurement submission.
+It also describes some optional information that submitters may decide to include.
 \wl
 
 \noindent
@@ -14,11 +15,12 @@ The section contains definitions of the terms used to describe the elements of a
 \label{sec:MDSpecs}
 \noindent
 Measuring devices must meet the Level requirements as defined in 
-Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}. This section defines meter accuracy requirements.
+Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}.
+This section defines meter accuracy requirements.
 \wl
 
 \noindent
-For Level~3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 1\% or better. 
+For Level~3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 1\% or better.
 Level~2 requires a meter with a minimum documented accuracy of 2\%.
 Level~1 requires a meter with a minimum documented accuracy of 5\%.
 \wl
@@ -58,7 +60,8 @@ For meters accepted by the spec power, refer to the {\itshape Power and Temperat
 \section{Measuring Device Terminology}
 \label{sec:MDTerm}
 \noindent
-Levels 1 and 2 specify power measurements. Level~3 specifies an energy measurement, but reports a power value.
+Levels 1 and 2 specify power measurements.
+Level~3 specifies an energy measurement, but reports a power value.
 
 \subsection{Sampling and Power Readings}
 \noindent
@@ -71,12 +74,14 @@ In that case, the intervals must not exceed one second by more than one sine wav
 \wl
 
 \noindent
-Sampling in an AC context requires a measurement stage that determines the true power delivered at that point and enters that value into a buffer where it is then used to calculate average power over a longer time.  So ``sampled once per second'' in this context means that the times in the buffer are averaged and recorded once per second.
-Sampling delivered electrical power in a DC context refers to a single simultaneous measurement of the voltage and the current to determine the delivered power at that point.  The sampling rate in this case is how often such a sample is taken and recorded internally within the device.  
+Sampling in an AC context requires a measurement stage that determines the true power delivered at that point and enters that value into a buffer where it is then used to calculate average power over a longer time.
+So ``sampled once per second'' in this context means that the times in the buffer are averaged and recorded once per second.
+Sampling delivered electrical power in a DC context refers to a single simultaneous measurement of the voltage and the current to determine the delivered power at that point.
+The sampling rate in this case is how often such a sample is taken and recorded internally within the device.
 \wl
 
 \noindent
-If the submitter is sampling in a DC context, most likely it will be necessary to adjust for power loss in the AC/DC conversion stage. 
+If the submitter is sampling in a DC context, most likely it will be necessary to adjust for power loss in the AC/DC conversion stage.
 Refer to Section~\numnameref{sec:A3SIiIP} for details.
 \wl
 
@@ -101,7 +106,7 @@ This subsection describes the difference of power-averaged measurements as requi
 \subsubsection{Power-Averaged Measurements}
 
 \noindent
-The reported power values for Levels 1 and 2 are power-averaged measurements over a certain time period (e.g. the core phase or the full run).
+The reported power values for Levels 1 and 2 are power-averaged measurements over a certain time period (e.g.~the core phase or the full run).
 A power-averaged measurement is one taken by a device that samples the instantaneous power used by a system at some fine time resolution for a specified interval.
 This interval is short compared to the full time of the power-averaged measurement.
 The power meter device numerically averages of all the instantaneous power measurements sampled during that interval.
@@ -109,7 +114,7 @@ This constitutes one measurement reported by the device covering that interval.
 Finally, the power-averaged measurement for the required time period is the average of all these power readings obtained from the device in that period.
 All power readings reported by the device for that period must be used except for one case:
 Exclude those readings for intervals that do not lie completely in the requested time period.
-(Usually the reading intervals and the measured time period (e.g. the core phase) are not synchronized.)
+(Usually the reading intervals and the measured time period (e.g.~the core phase) are not synchronized.)
 We require that the internal device sampling rate must be at least 1 Hz and constant.
 The intervals between the power readings must be constant and no longer than 10\% of the duration of the core phase.
 (This ensures that the parts of the core phase that are not measured at beginning and end are not significant.)
@@ -118,12 +123,13 @@ In that case, the averaging process must weight the power readings from the powe
 \wl
 
 \noindent
-Consider Level~1, which requires only one reported power value. 
+Consider Level~1, which requires only one reported power value.
 This reported power value may consist of several power readings taken at a constant frequency of at least once per minute.
 Each such reading itself must be the average of instantaneous power samples measured at least once per second and averaged over reading interval.
 For Level~1, the time period that is measured must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
 For example, if the device reports one power measurement every 5 seconds (each being the average of at least 5 power samples) and the core phase takes 10 minutes, Level~1 reports one power-averaged value that averages over all the 120 measurements obtained during the core phase.
-(Usually the power reading intervals and the core phase are not synchronized, such that the first reding does not lie completely in the core phase. In that case the average is only over the 119 readings completely in the core phase.)
+(Usually the power reading intervals and the core phase are not synchronized, such that the first reding does not lie completely in the core phase.
+In that case the average is only over the 119 readings completely in the core phase.)
 \wl
 
 \noindent
@@ -147,7 +153,11 @@ For Levels 1 and 2, the units of the reported power values are watts.
 \subsubsection{Total Energy Measurements}
 
 \noindent
-Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power. An integrated measurement is a continuing sum of energy measurements. Typically, there are hundreds of measurements per second.  Depending on the local AC power line frequency, there must be at least 120 or 100 measurements per second. The measuring device samples voltage and current many times per second and integrate those samples to determine the next total energy consumed reading. 
+Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power.
+An integrated measurement is a continuing sum of energy measurements.
+Typically, there are hundreds of measurements per second.
+Depending on the local AC power line frequency, there must be at least 120 or 100 measurements per second.
+The measuring device samples voltage and current many times per second and integrate those samples to determine the next total energy consumed reading.
 \wl
 
 \noindent
@@ -158,7 +168,8 @@ The final value for the full run must be obtained analogously.
 \wl
 
 \noindent
-The difference between the initial and final energy readings are the total energy measurement in joule. The reported values after the energy has been divided by the elapsed time are watts as for levels 1 and 2.
+The difference between the initial and final energy readings are the total energy measurement in joule.
+The reported values after the energy has been divided by the elapsed time are watts as for levels 1 and 2.
 
 \section{Aspect and Quality Levels}
 \label{sec:AQLevels}
@@ -205,8 +216,8 @@ $\bullet$ idle power \\
 \hline
 
 \textbf{2: Machine \newline fraction}  &
-The greater of \frac{1}{10} of the compute subsystem or 2~kW or 15~compute nodes. Alternatively at least 40~kW or the entire system. &
-The greater of \frac{1}{8] of the compute-node subsystem or 10~kW or 15~compute nodes &
+The greater of $\frac{1}{10}$ of the compute subsystem or 2~kW or 15~compute nodes - alternatively at least 40~kW or the entire system &
+The greater of $\frac{1}{8}$ of the compute-node subsystem or 10~kW or 15~compute nodes &
 The whole of all included subsystems \\
 \hline
 
@@ -242,19 +253,24 @@ Conversion loss measured simultaneously \\
 \section{Aspect 1: Granularity, Timespan and Reported Measurements}
 \label{sec:A1GTRM}
 \noindent
-Aspect 1 has the following three parts. Levels 1, 2, and 3 satisfy this aspect in different ways.
+Aspect~1 has the following three parts.
+Levels~1, 2, and~3 satisfy this aspect in different ways.
 
 \begin{itemize}
 \item
-The granularity of power measurements. This aspect determines the number of measurements per time element.
+The granularity of power measurements.
+This aspect determines the number of measurements per time element.
 \item
-The timespan of power measurements. This aspect determines where in the time of the workload's execution the power measurements are taken.
+The timespan of power measurements.
+This aspect determines where in the time of the workload's execution the power measurements are taken.
 \item
-The reported measurements. This aspect describes how the power measurements are reported.
+The reported measurements.
+This aspect describes how the power measurements are reported.
 \end{itemize}
 
 \noindent
-For all required measurements, the submission must also include the data used to calculate them. For Level~2 and Level~3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core phase of the run. 
+For all required measurements, the submission must also include the data used to calculate them.
+For Level~2 and Level~3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core phase of the run.
 \wl
 
 \noindent
@@ -269,24 +285,30 @@ This ensures that a uniform standard of \textit{beginning} and \textit{end} of t
 \end{itemize}
 
 \noindent
-There is no maximum number of reported measurement values, although one reported measurement per second is a reasonable upper limit. The submitter may choose to include more than 10 such measurement values.
+There is no maximum number of reported measurement values, although one reported measurement per second is a reasonable upper limit.
+The submitter may choose to include more than 10 such measurement values.
 \wl
 
 \noindent
-The number of reported average power measurements or total energy measurements is deliberately given large latitude.  Different computational machines will run long or short benchmark runs, depending on the size of the machine, the memory footprint per node, as well as other factors.  Typically the power measurement infrastructure is not directly tied to the computational system's OS and has its own baseline configuration (say, one averaged measurement every five minutes).  These requirements are specified not only to give a rich data set but also to be compatible with typical data center power measurement infrastructure.
+The number of reported average power measurements or total energy measurements is deliberately given large latitude.
+Different computational machines will run long or short benchmark runs, depending on the size of the machine, the memory footprint per node, as well as other factors.
+Typically the power measurement infrastructure is not directly tied to the computational system's OS and has its own baseline configuration (say, one averaged measurement every five minutes).
+These requirements are specified not only to give a rich data set but also to be compatible with typical data center power measurement infrastructure.
 \wl
 
 \noindent
-All levels specify that power measurements be performed within the core phase of a workload. Levels 2 and 3 specify that a power measurement for the entire application be reported. Consequently, these levels require measurements during the run but outside of the core phase.
+All levels specify that power measurements be performed within the core phase of a workload.
+Levels~2 and~3 specify that a power measurement for the entire application be reported.
+Consequently, these levels require measurements during the run but outside of the core phase.
 
 \subsection{Core Phase}
 \label{sec:core_phase}
 \noindent
-All submissions must include the average power within the core phase of the run. 
+All submissions must include the average power within the core phase of the run.
 \wl
 
 \noindent
-The core phase is usually considered to be the section of the workload that undergoes parallel execution. 
+The core phase is usually considered to be the section of the workload that undergoes parallel execution.
 It typically does not include the parallel job launch and teardown and is required to run for at least one minute.
 \wl
 
@@ -309,7 +331,7 @@ HPL\_pdgesv() end time Wed Jun 30 22:23:15 2015
 
 \subsection{The Whole Run}
 \noindent
-Level~2 and Level~3 submissions must also include the average power for the whole run, from the initiation of the job to its completion. 
+Level~2 and Level~3 submissions must also include the average power for the whole run, from the initiation of the job to its completion.
 \wl
 
 \noindent
@@ -317,11 +339,16 @@ Since HPL only reports the time spent executing the core phase of the workload, 
 \wl
 
 \noindent
-Levels 2 and 3 require the entire run to be measured and reported because HPL (the default workload at the time this document was written) drops significantly in power consumption during the course of a computation, as the matrix size being computed gets smaller.  Requiring the entire run eliminates systematic bias caused by using different parts of the run for the measurement. Figure~\ref{fig:powprof} shows an example of a power graph taken from an HPL run on the LLNL Muir system in the fall of 2011.
+Levels 2 and 3 require the entire run to be measured and reported because HPL (the default workload at the time this document was written) drops significantly in power consumption during the course of a computation, as the matrix size being computed gets smaller.
+Requiring the entire run eliminates systematic bias caused by using different parts of the run for the measurement.
+Figure~\ref{fig:powprof} shows an example of a power graph taken from an HPL run on the LLNL Muir system in the fall of 2011.
 \wl
 
 \noindent
-Note that the power drops by 8\% or so during the computational phase of the run.  This graph also illustrates the need for the device measurement to have as high a time resolution as possible.  The spread of power measurements even within a small time span is very likely caused by the sampling going in and out of phase with the AC input power. Figure~\ref{fig:sopm} shows a smaller time slice that clearly illustrates this.
+Note that the power drops by 8\% or so during the computational phase of the run.
+This graph also illustrates the need for the device measurement to have as high a time resolution as possible.
+The spread of power measurements even within a small time span is very likely caused by the sampling going in and out of phase with the AC input power.
+Figure~\ref{fig:sopm} shows a smaller time slice that clearly illustrates this.
 \wl
 
 
@@ -342,17 +369,20 @@ Note that the power drops by 8\% or so during the computational phase of the run
 \end{figure}
 
 \noindent
-The boxes are individual one-second power samples.  This fast up-down fluctuation is not caused by the behavior of an individual power supply; the power being sampled is over the entire computer system doing the HPL run.  The reason that L3 requires integrating total energy meters is because they measure at a high enough sampling rates to not be subject to these sampling artifacts.
+The boxes are individual one-second power samples.
+This fast up-down fluctuation is not caused by the behavior of an individual power supply; the power being sampled is over the entire computer system doing the HPL run.
+The reason that L3 requires integrating total energy meters is because they measure at a high enough sampling rates to not be subject to these sampling artifacts.
 \wl
 
 \noindent
 L3 requires a power-meter device with a higher inherent measurement granularity as compared to L1 and L2.
 L1 / L2 allow 1-second intervals of the input power.
-L3 requires an integrating total-energy meter, which samples the input power multiple times per AC cycle and so is much less susceptible to sampling artifacts caused by the AC waveform.  
+L3 requires an integrating total-energy meter, which samples the input power multiple times per AC cycle and so is much less susceptible to sampling artifacts caused by the AC waveform.
 
 \subsection{Level~1}
 \noindent
-The device measurement granularity must be at least one instantaneous measurement of power per second. This requirement holds whether the measurement is DC or AC.
+The device measurement granularity must be at least one instantaneous measurement of power per second.
+This requirement holds whether the measurement is DC or AC.
 \wl
 
 \noindent
@@ -363,7 +393,10 @@ least one minute long.
 
 \subsection{Level~2}
 \noindent
-Level~2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run. The workload run must have a series of power-averaged measurements at constant time intervals. These measurement intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload. The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.  
+Level~2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run.
+The workload run must have a series of power-averaged measurements at constant time intervals.
+These measurement intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload.
+The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.
 \wl
 
 \noindent
@@ -372,12 +405,15 @@ The device measurement sampling granularity must be at least one instantaneous m
 \wl
 
 \noindent
-There is some unspecified number of power-averaged measurements during the workload but outside of the core phase. The reported average power for the whole run will be the numerical average of the power measurements for the whole run.  
+There is some unspecified number of power-averaged measurements during the workload but outside of the core phase.
+The reported average power for the whole run will be the numerical average of the power measurements for the whole run.
 \wl
 
 
 \noindent
-Figure~\ref{fig:a1l2pm} illustrates Aspect~1 of a Level~2 power measurement. Each measurement is an average of instantaneous power measurements, and these instantaneous measurements are taken once per second. As an example, the figure shows 10 power-averaged measurements within the core phase and four power-averaged measurements outside the core phase, two before the core phase and two after the core phase.
+Figure~\ref{fig:a1l2pm} illustrates Aspect~1 of a Level~2 power measurement.
+Each measurement is an average of instantaneous power measurements, and these instantaneous measurements are taken once per second.
+As an example, the figure shows 10 power-averaged measurements within the core phase and four power-averaged measurements outside the core phase, two before the core phase and two after the core phase.
 
 %INCLUDE FIG 3-4
 \begin{figure}
@@ -393,24 +429,30 @@ Level~3 submissions include a measurement of the average power during the core p
 \wl
 
 \noindent
-The complete set of total energy readings (at least 10 during the core computation phase) must be included, along with the execution time for the core phase and full run. 
+The complete set of total energy readings (at least 10 during the core computation phase) must be included, along with the execution time for the core phase and full run.
 \wl
 
 \noindent
-Level~3 requires continuously integrated total energy measurements rather than power-averaged measurements. The readings must begin before the start of the run and extend to when it is finished.
+Level~3 requires continuously integrated total energy measurements rather than power-averaged measurements.
+The readings must begin before the start of the run and extend to when it is finished.
 \wl
 
 \noindent
-The measuring device must sample voltage and current, whether AC or DC, at least 120 times or 100 times per second (depending on the local AC power line frequency) and integrate those samples to determine the next total energy consumed reading.  Sampling at a greater rate is permitted. 
+The measuring device must sample voltage and current, whether AC or DC, at least 120 times or 100 times per second (depending on the local AC power line frequency) and integrate those samples to determine the next total energy consumed reading.
+Sampling at a greater rate is permitted.
 \wl
 
 \noindent
-The intervals at which total energy readings are reported must be short enough so that at least 10 reported readings fall within the core phase of the workload. Note that each reported energy reading is the integral over many internal power samples.
+The intervals at which total energy readings are reported must be short enough so that at least 10 reported readings fall within the core phase of the workload.
+Note that each reported energy reading is the integral over many internal power samples.
 \wl
 
 
 \noindent
-Figure~\ref{fig:a1l3pm} illustrates Aspect~1 of  Level~3 power measurement. The figure shows 10 readings in the core phase of the workload. Note that these are integrated readings.  To obtain a power reading, one must subtract two integrated readings and divide by the time between the readings.
+Figure~\ref{fig:a1l3pm} illustrates Aspect~1 of  Level~3 power measurement.
+The figure shows 10 readings in the core phase of the workload.
+Note that these are integrated readings.
+To obtain a power reading, one must subtract two integrated readings and divide by the time between the readings.
 
 %INCLUDE FIG 3-5
 \begin{figure}[t]
@@ -423,11 +465,14 @@ Figure~\ref{fig:a1l3pm} illustrates Aspect~1 of  Level~3 power measurement. The 
 \section{Format of Reported Measurements}
 \label{sec:FoRM}
 \noindent
-Levels 2 and 3 require the complete set of measurements. The submitter may choose to provide these values in a CSV file. Do not provide scans of paper documents.
+Levels 2 and 3 require the complete set of measurements.
+The submitter may choose to provide these values in a CSV file.
+Do not provide scans of paper documents.
 \wl
 
 \noindent
-The submitter may find it useful to create a graph showing the power and energy during the workload as shown in Figure~\ref{fig:powengwl}. Keep this graph for reference, but do not provide it as part of the submission.
+The submitter may find it useful to create a graph showing the power and energy during the workload as shown in Figure~\ref{fig:powengwl}.
+Keep this graph for reference, but do not provide it as part of the submission.
 
 
 %INCLUDE FIG 3-6
@@ -442,19 +487,22 @@ The submitter may find it useful to create a graph showing the power and energy 
 \section{Aspect 2: Machine Fraction Instrumented}
 \label{sec:A2MFI}
 \noindent
-Aspect~2 specifies the fraction of the system whose power feeds are instrumented by the measuring equipment. 
+Aspect~2 specifies the fraction of the system whose power feeds are instrumented by the measuring equipment.
 \wl
 
 \noindent
-Level~3 requires that the entire machine be measured. Level~2 requires a higher fraction than Level~1.
+Level~3 requires that the entire machine be measured.
+Level~2 requires a higher fraction than Level~1.
 \wl
 
 \noindent
 Levels 1 and 2 do not measure the power of the entire system, but require only a measurement of a fraction of the system and estimate the total power consumotion by extrapolation.
 When calculating the average power of the full machine for Levels 1 and 2, the measured power must be divided by this fraction to 
-extrapolate to the average power drawn by the whole machine. For example, if the submitter measures the power delivered 
-to $ \frac{1}{4} $ of the machine, the submitter must then multiply the measured power by 4 to obtain the power for the whole machine.  
-The higher machine fractions are required at the higher quality levels to reduce the effects of random fluctuations and minor differences in hardware influencing the power measurements.  The larger the sample, the more transients will tend to cancel out.
+extrapolate to the average power drawn by the whole machine.
+For example, if the submitter measures the power delivered 
+to $ \frac{1}{4} $ of the machine, the submitter must then multiply the measured power by 4 to obtain the power for the whole machine.
+The higher machine fractions are required at the higher quality levels to reduce the effects of random fluctuations and minor differences in hardware influencing the power measurements.
+The larger the sample, the more transients will tend to cancel out.
 \wl
 
 \noindent
@@ -462,7 +510,8 @@ The requirements with respect to the compute-node subsystem for each quality lev
 
 \begin{itemize}
 \item
-L1: The largest of $\frac{1}{10}$ of the compute-node subsystem or at least 2~kW or 15 compute nodes. Alternatively, at least 40~kW or the entiry system.
+L1: The largest of $\frac{1}{10}$ of the compute-node subsystem or at least 2~kW or 15 compute nodes.
+Alternatively, at least 40~kW or the entiry system.
 \item
 L2: The largest of $\frac{1}{8}$ of the compute-node subsystem or at least 10~kW or 15 compute nodes.
 \item
@@ -482,7 +531,8 @@ Even if individual node power could be measured, that would not be valid as it w
 \noindent
 The requirement for Level~1 and Level~2 include the measurement of at least 15 nodes.
 For a cluster consisting of individual servers, a node is simply defined as one server.
-There are architectures with multiple individual servers in one chassis, e.g. 2U twin or twin$^2$ servers with 2 and 4 servers per chassis and blade servers with many more nodes in one chassis.
+There are architectures with multiple individual servers in one chassis, e.g.
+2U twin or twin$^2$ servers with 2 and 4 servers per chassis and blade servers with many more nodes in one chassis.
 Usually, all the nodes in one chassis share redundant power supplies.
 In that case, you have to measure entire chassis, including all the power supplies of a chassis.
 The measurement of a chassis is then considered a measurement of as many nodes as there are nodes in the chassis.
@@ -498,11 +548,12 @@ It is not allowed to screen the system for components with lower power consumtio
 \section{Aspect 3: Subsystems Included in Instrumented Power}
 \label{sec:A3SIiIP}
 \noindent
-Aspect 3 specifies the subsystems included in the instrumented power. 
+Aspect 3 specifies the subsystems included in the instrumented power.
 \wl
 
 \noindent
-Subsystems in the context of this document are power subsystems. A power subsystem is that part of a supercomputer which can be measured in isolation for power consumption while the supercomputer is performing a task. 
+Subsystems in the context of this document are power subsystems.
+A power subsystem is that part of a supercomputer which can be measured in isolation for power consumption while the supercomputer is performing a task.
 \wl
 
 \noindent
@@ -510,18 +561,19 @@ Subsystems include computational nodes, any interconnect network the application
 \wl
 
 \noindent
-If some subsystems are part of the measured power, their power may not be subtracted out after the fact.  The explicitly measured value must be used as is.
+If some subsystems are part of the measured power, their power may not be subtracted out after the fact.
+The explicitly measured value must be used as is.
 \wl
 
 
 \noindent
-For Level~1, both the compute-node subsystem and the interconnect must be reported.  
-The compute-node subsystem power must be measured. 
+For Level~1, both the compute-node subsystem and the interconnect must be reported.
+The compute-node subsystem power must be measured.
 The interconnect subsystem participating in the workload must also be measured or, if not measured, the contribution must be estimated.
-Include everything that you need to operate the interconnect network that is not part of the compute subsystem. 
+Include everything that you need to operate the interconnect network that is not part of the compute subsystem.
 This may include infrastructure that is shared, but excludes parts that are not servicing the system under test.
-For some systems, it may be impossible not to include a power contribution from some subsystems. 
-In this case, provide a list of the measured subsystems, but do not subtract an estimated value for the included subsystem. 
+For some systems, it may be impossible not to include a power contribution from some subsystems.
+In this case, provide a list of the measured subsystems, but do not subtract an estimated value for the included subsystem.
 \wl
 
 \noindent
@@ -530,8 +582,8 @@ Other subsystems participating in the workload must be measured or estimated.
 \wl
 
 \noindent
-For Level~3, all power going to the parts of a computer system that participate in a workload must be included in the power measurement. 
-The reported power measurement must include all computational nodes, any interconnect network the application uses, any head or control nodes, any storage system the application uses, all power conversion losses inside the computer, and any internal cooling devices (self-contained liquid cooling systems and fans).  
+For Level~3, all power going to the parts of a computer system that participate in a workload must be included in the power measurement.
+The reported power measurement must include all computational nodes, any interconnect network the application uses, any head or control nodes, any storage system the application uses, all power conversion losses inside the computer, and any internal cooling devices (self-contained liquid cooling systems and fans).
 \wl
 
 \noindent
@@ -539,19 +591,26 @@ For Levels 1 and 2, estimations of other subsystems besides the compute subsyste
 \wl
 
 \noindent
-For Levels 2 and 3, the reported power measurement may exclude storage subsystems that don't participate in the workload. It is not required to exclude such storage subsystems. However, if these storage subsystems are part of the cabinet or rack being measured, they may not be excluded even if they are not used. That is, the submitter cannot calculate their contribution and subtract that contribution. If the storage subsystem is not part of the rack or cabinet being measured and it does not participate in the workload, it need not be measured.
+For Levels 2 and 3, the reported power measurement may exclude storage subsystems that don't participate in the workload.
+It is not required to exclude such storage subsystems.
+However, if these storage subsystems are part of the cabinet or rack being measured, they may not be excluded even if they are not used.
+That is, the submitter cannot calculate their contribution and subtract that contribution.
+If the storage subsystem is not part of the rack or cabinet being measured and it does not participate in the workload, it need not be measured.
 \wl
 
 \noindent
-In some cases, the submitter may be measuring power that the application doesn't actually use. If the submitter can exclude the unused subsystems from the measurement or easily turn off the power to the unused subsystems, then the submitter can choose not to include those subsystems in the measurement. 
+In some cases, the submitter may be measuring power that the application doesn't actually use.
+If the submitter can exclude the unused subsystems from the measurement or easily turn off the power to the unused subsystems, then the submitter can choose not to include those subsystems in the measurement.
 \wl
 
 \noindent
-For example, the node board may include compute nodes and GPUs, and the application may not actually use the GPUs.  If you cannot easily shut down the GPUs (say with an API), you must still include the power that they use. It is not acceptable to measure the power for both the compute nodes and the GPUs and then subtract the GPU power from the measurement.
+For example, the node board may include compute nodes and GPUs, and the application may not actually use the GPUs.
+If you cannot easily shut down the GPUs (say with an API), you must still include the power that they use.
+It is not acceptable to measure the power for both the compute nodes and the GPUs and then subtract the GPU power from the measurement.
 \wl
 
 \noindent
-A site may include more subsystems than are strictly required if it chooses or if it is advantageous from a measurement logistics point of view.  
+A site may include more subsystems than are strictly required if it chooses or if it is advantageous from a measurement logistics point of view.
 \wl
 
 \noindent
@@ -561,20 +620,21 @@ These compute nodes are said to belong to different heterogeneous sets.
 \wl
 
 \noindent
-With Level~3, the submitter need not be concerned about heterogeneous sets of compute nodes because Level~3 measures the entire system. 
+With Level~3, the submitter need not be concerned about heterogeneous sets of compute nodes because Level~3 measures the entire system.
 \wl
 
 \noindent
 Levels 1 and 2, however, measure a portion of the compute-node subsystem and estimate contributions from unmeasured portions.
 With Levels 1 and 2, the submitter must measure at least one member of each heterogeneous set.
-Measure at least 10\% of each heterogeneous set for Level~1, and at least \frac{1}{8} of each heterogeneous set for Level~2.
+Measure at least 10\% of each heterogeneous set for Level~1, and at least $\frac{1}{8}$ of each heterogeneous set for Level~2.
 Then, extrapolate the total power per each heterogeneous set as you would do for a non heterogeneous cluster.
 Finally, accumulate the contributions of all heterogeneous sets.
 \wl
 
 \noindent
-For example, assume there exist two sets of compute nodes, a set called A and another called B.  The submitter is able to measure the power 
-consumed by $ \frac{1}{2} $ of the A compute nodes and $ \frac{1}{4} $ of the B compute nodes.
+For example, assume there exist two sets of compute nodes, a set called A and another called B.
+The submitter is able to measure the power 
+consumed by $ \frac{1}{2} $ of the A compute nodes and $\frac{1}{4}$ of the B compute nodes.
 \wl
 
 \noindent
@@ -589,19 +649,23 @@ The assumption of Levels 2 and 1 is that all the compute nodes in a set react id
 
 \section{Aspect 4: Instrumentation Location where the Electrical Measurements are Taken}
 \label{sec:A4wEMaT}
-Aspect 4 specifies where in the power distribution system the power delivery is measured.  For all quality levels, the submission indicates where power is measured and the quantity of parallel measurements.
+Aspect 4 specifies where in the power distribution system the power delivery is measured.
+For all quality levels, the submission indicates where power is measured and the quantity of parallel measurements.
 \wl
 
 \noindent
-Measurements of power or energy are typically made at multiple locations in parallel across the computer system. For example, such locations can be at the entrance to each separate rack, or at the output connector of multiple building transformers. 
+Measurements of power or energy are typically made at multiple locations in parallel across the computer system.
+For example, such locations can be at the entrance to each separate rack, or at the output connector of multiple building transformers.
 \wl
 
 \noindent
-All the reported measurements taken in parallel at a given instant in time are then summed into a total measurement for that time.  The total measurement for a given moment in time constitutes one entry in the series of measurements that becomes part of the submission.
+All the reported measurements taken in parallel at a given instant in time are then summed into a total measurement for that time.
+The total measurement for a given moment in time constitutes one entry in the series of measurements that becomes part of the submission.
 \wl
 
 \noindent
-AC measurements are upstream of the system's power conversion. If the measurements are in a DC context, the submitter may have to take into account some power loss. 
+AC measurements are upstream of the system's power conversion.
+If the measurements are in a DC context, the submitter may have to take into account some power loss.
 Refer to Section~\numnameref{sec:AfPL}.
 \wl
 
@@ -620,7 +684,8 @@ At the location of the electrical supply delivery to the computer system from th
 OR
 
 \item[{C)}]
-At a location just inside of the computer system that is electrically equivalent to location B) above.  This includes the following. 
+At a location just inside of the computer system that is electrically equivalent to location B) above.
+This includes the following.
 
 \begin{itemize}
 \item
@@ -640,15 +705,15 @@ Refer to Section~\ref{sec:MDSpecs} for the specifications of the required accura
 \subsection{Adjusting for Power Loss}
 \label{sec:AfPL}
 \noindent
-If the measurement device(s) that satisfy Aspect 1 are downstream of the ABC locations specified above, then two sets of measurements must be taken in order to determine the power loss between the required and the actual measurement location. 
+If the measurement device(s) that satisfy Aspect 1 are downstream of the ABC locations specified above, then two sets of measurements must be taken in order to determine the power loss between the required and the actual measurement location.
 
 \begin{itemize}
 \item
-For a Level~1 measurement, the power loss may be a load-varying model based on specifications from the manufacturer.  
+For a Level~1 measurement, the power loss may be a load-varying model based on specifications from the manufacturer.
 \item
-For a Level~2 measurement, the power loss may be a load-varying model based on an actual physical measurement of one power supply in the system.  
+For a Level~2 measurement, the power loss may be a load-varying model based on an actual physical measurement of one power supply in the system.
 \item
-For a Level~3 submission, the power loss must be measured simultaneously by a device at the required location (one of the ABC locations) measured at least once every five minutes, averaged long enough to average out the AC transients. 
+For a Level~3 submission, the power loss must be measured simultaneously by a device at the required location (one of the ABC locations) measured at least once every five minutes, averaged long enough to average out the AC transients.
 \end{itemize}
 
 \noindent
@@ -656,12 +721,14 @@ For all three levels, the power losses used and how they were determined must be
 
 \subsection{Data Center Schematic}
 \noindent
-Figure~\ref{fig:powmeasschem} is an example of a simple power measurement schematic. This example shows only one power measurement location.
+Figure~\ref{fig:powmeasschem} is an example of a simple power measurement schematic.
+This example shows only one power measurement location.
 \wl
 
 
 \noindent
-Submitters may find it useful to create such a schematic to identify the power measurement locations. Keep this schematic for reference, but do not provide it as part of the submission.
+Submitters may find it useful to create such a schematic to identify the power measurement locations.
+Keep this schematic for reference, but do not provide it as part of the submission.
 
 %INCLUDE FIG 3-7
 \begin{figure}
@@ -683,7 +750,7 @@ Reporting temperature allows for better comparison of reported results, as there
 \wl
 
 \noindent
-All other environmental data is optional. 
+All other environmental data is optional.
 Other environmental data may include factors such as:
 
 \begin{packed_item}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -64,6 +64,9 @@ Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented
 
 \subsection{Power-Averaged and Total Energy Measurements}
 \label{sec:PAaTEM}
+
+\subsubsection{Power-Averaged Measurements}
+
 \noindent
 The reported power values for Levels 1 and 2 are power-averaged measurements.
 A power-averaged measurement is one taken by a device that samples the instantaneous power used by a system at some fine time resolution for a given interval.
@@ -110,6 +113,8 @@ Although those two measurements were equally spaced over 500 minutes , each aver
 \noindent
 For Levels 1 and 2, the units of the reported power values are watts.
 \wl
+
+\subsubsection{Total Energy Measurements}
 
 \noindent
 Level 3 specifies a total energy measurement that, when divided by the measured time, also reports power. An integrated measurement is a continuing sum of energy measurements. Typically, there are hundreds of measurements per second.  Depending on the local frequency standard, there must be at least 120 or 100 measurements per second. The measuring device samples voltage and current many times per second and integrates those samples to determine the next total energy consumed reading. 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -198,7 +198,7 @@ Table~\ref{tab:levels} summarizes the aspect and quality levels introduced in Se
 \textbf{1a:~Granularity} &
 One power sample per second &
 One power sample per second &
-Continuously integrated energy\\
+Continuously integrated energy, voltage and current sampled at \SpecRateLThreeAC{} for AC / \SpecRateLThreeDC{} for DC \\
 \hline
 
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -11,13 +11,19 @@ This section contains:
 \end{itemize}
 \wl
 
-\section{Measuring Device Specifications}
+\section{Measuring Device Terminology and Specifications}
 \label{sec:MDSpecs}
+\label{sec:MDTerm}
+
 \noindent
-Measuring devices must meet the Level requirements as defined in 
-Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}.
 This section defines meter accuracy requirements.
+First, subsection~\ref{sec:accuracy} defines the general accuray requirements.
+The following section describe the different types of measurements and the required sampling rates. 
+Measuring devices must also meet the Level requirements as defined in Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}.
 \wl
+
+\subsection{Accuracy Requirements}
+\label{sec:accuracy}
 
 \noindent
 For Level~3, it is required to use any revenue grade meter, any meter accepted by SPEC power, or any meter documented to have an accuracy of \SpecAccuracyLThree{} or better.
@@ -61,12 +67,6 @@ For meters accepted by the SPEC power, refer to the {\itshape Power and Temperat
 \url{http://www.spec.org/power/docs/SPECpower-Device_List.html }
 \end{packed_item}
 \wl
-
-\section{Measuring Device Terminology}
-\label{sec:MDTerm}
-\noindent
-Levels~1 and~2 specify power measurements.
-Level~3 specifies an energy measurement, but reports a power value.
 
 \subsection{Sampling and Power Readings}
 \noindent
@@ -112,7 +112,11 @@ Usually, the power meter will take many samples per second and report power read
 \subsection{Power-Averaged and Total Energy Measurements}
 \label{sec:PAaTEM}
 
+\noindent
 This subsection describes the difference of power-averaged measurements as required for Level~1 and Level~2 as compared to total energy measurements as required for Level~3.
+Levels~1 and~2 specify power measurements.
+Level~3 specifies an energy measurement, but reports a power value.
+\wl
 
 \subsubsection{Power-Averaged Measurements (Levels~1 and~2)}
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -33,6 +33,11 @@ It is acceptable if the error is documented either as a hard bound, as the 1$\si
 \wl
 
 \noindent
+All requirements and operating conditions that are required for the power meter to achieve its documented accuracy must be met.
+For Levels~1 and~2 it is allowed to assume that the AC net power is a sine wave function.
+\wl
+
+\noindent
 If the site uses multiple independent power meters for a Level~2 or a Level~3 measurement, and if all employed power meters measure an identical fraction of the system, the requirements are relaxed in the following way.
 \begin{packed_item}
 \item 
@@ -155,9 +160,9 @@ For Levels~1 and~2, the units of the reported power values are watts.
 \noindent
 Level~3 specifies a total energy measurement that, when divided by the measured time, also reports power.
 An integrated measurement is a continuing sum of energy measurements.
-Typically, there are hundreds of measurements per second.
-Depending on the local AC power line frequency, there must be at least 120 or 100 measurements per second.
 The measuring device samples voltage and current many times per second and integrate those samples to determine the next total energy consumed reading.
+Typically, there are hundreds of measurements per second.
+It is requested that the power meter samples at least at 120~Hz for a DC measurement and at least at~5kHz for an AC measurement.
 \wl
 
 \noindent
@@ -438,7 +443,8 @@ The readings must begin before the start of the run and extend to when it is fin
 \wl
 
 \noindent
-The measuring device must sample voltage and current, whether AC or DC, at least 120 times or 100 times per second (depending on the local AC power line frequency) and integrate those samples to determine the next total energy consumed reading.
+The measuring device must sample voltage and current at high rate and integrate those samples to determine the next total energy consumed reading.
+The sampling rate must be at least 120~Hz for DC, and at least 5~kHz for AC.
 Sampling at a greater rate is permitted.
 \wl
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -300,7 +300,7 @@ Therefore, Level~1 and Level~2 allow a small part at the beginning and at the en
 \noindent
 For example, the core phase of the Linpack workload is the portion of the code that actually solves the matrix.
 It is the numerically intensive solver phase of the calculation.
-In case of the standard HPL implementation of the Linpack benchmark as provided by netlib.ork (\url{http://www.netlib.org/benchmark/hpl/}) this is the time spent in the routing {\ttfamily HPL\_pdgesv}.
+In case of the standard HPL implementation of the Linpack benchmark as provided by netlib.org (\url{http://www.netlib.org/benchmark/hpl/}) this is the time spent in the routing {\ttfamily HPL\_pdgesv}.
 Note that HPL as of version 2.1 contains a timer routine that prints start and end time of the core phase to facilitate power measurements, which looks like:\newline
 {\ttfamily
 HPL\_pdgesv() start time Wed Jun 30 21:49:08 2015\newline

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -22,15 +22,35 @@ Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}. This section defines meter acc
 \wl
 
 \noindent
-For Level 3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 3\% or better. 
+For Level 3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 1\% or better. 
 Revenue grade meters are defined by ANSI C12.20.  
-Level 2 requires a meter with a minimum documented accuracy of 3\%.
+Level 2 requires a meter with a minimum documented accuracy of 2\%.
 Level 1 requires a meter with a minimum documented accuracy of 5\%.
 \wl
 
 \noindent
-Also, refer to 
-the {\itshape Power and Temperature Measurement Setup Guide \/} and the list of accepted power measurement devices from the Standard Performance Evaluation Corporation.
+The required accuracy as percentage refers to the relative error specified for the power meter.
+If the power meter has multiple measurement intervals with different accuracies, all measurement intervals used during the benchmark run must meet the above requirements.
+Error in this context refers to the sum of statistical and systematic error.
+It is acceptable if the error is documented either as a hard bound, as the 1$\sigma$ standard deviation, or as the full width at half maximum (FWHM).
+\wl
+
+\noindent
+If the site uses multiple independent power meters for a level 2 or a level 3 measurement, and if all employed power meters measure an identical fraction of the system, the requirements are relaxed in the following way.
+\begin{packed_item}
+\item 
+Each individual power meter must have at least a documented accuracy of 3\%.
+\item
+The documented error of the individual meters divided by the square root of the number of employed meters must meet the above requirements of 2\% for level 2 and 1\% for level 1.
+\end{packed_item}
+In this case, the second requirement ensures that the standard deviation of the measurement of the entire run, using error propagation, and assuming a gaussian distribution, and assuming that the errors of the power meters are uncorelated, meets the requirements.
+For example, assume 4 power meters for a level 3 measurement, each measuring 25\% of the total system.
+In that case, each meter must have a documented accuracy of~$1\% \cdot \sqrt{4} = 2\%$.
+In other words, you can use a single meter with 1\% accuracy, 4 meters with 2\% accuracy, or 9 meters with 3\% accuracy for level 3.
+\wl
+
+\noindent
+For meters accepted by the spec power, refer to the {\itshape Power and Temperature Measurement Setup Guide \/} and the list of accepted power measurement devices from the Standard Performance Evaluation Corporation.
 \wl
 
 \noindent
@@ -156,7 +176,7 @@ Equally spaced across the full run   \\
 \textbf{1c:~Measurements} &
 Core phase average power &
 $\bullet$ Core phase average power & 
-$\bullet$ Core phase total energy \\
+$\bullet$ Core phase total energy \\MDSpecs
 
  & &
 $\bullet$ Full run average power &
@@ -164,7 +184,7 @@ $\bullet$ Full run total energy \\
 
  & &
 $\bullet$ 10 average power measurements in the core phase &
-$\bullet$ 10 total energy measurements in the core phase \\
+$\bullet$ 10 total energy measureMDSpecsments in the core phase \\
 
  & &
 $\bullet$ idle power &
@@ -200,8 +220,8 @@ Conversion loss measured simultaneously \\
 \hline
 \textbf{4b: Meter accuracy} &
 5\% &
-3\% &
-3\% \\
+2\% (see Section~\ref{sec:MDSpecs})&
+1\% (see Section~\ref{sec:MDSpecs})\\
 \hline
 \end{tabular}
 \end{table}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -555,7 +555,9 @@ A site may include more subsystems than are strictly required if it chooses or i
 \wl
 
 \noindent
-A particular system may have different types of compute nodes. The system may have compute nodes from different companies or even compute nodes with different architectures. These compute nodes are said to belong to different heterogeneous sets.
+A particular system may have different types of compute nodes.
+The system may have compute nodes from different companies or even compute nodes with different architectures.
+These compute nodes are said to belong to different heterogeneous sets.
 \wl
 
 \noindent
@@ -563,7 +565,11 @@ With Level~3, the submitter need not be concerned about heterogeneous sets of co
 \wl
 
 \noindent
-Levels 1 and 2, however, measure a portion of the compute-node subsystem and estimate contributions from unmeasured portions. With Levels 1 and 2, the submitter must measure at least one member of each heterogeneous set. The submitter must include a power measurement from at least one compute node in each heterogeneous set and then estimate the contribution from the remaining members of the set. 
+Levels 1 and 2, however, measure a portion of the compute-node subsystem and estimate contributions from unmeasured portions.
+With Levels 1 and 2, the submitter must measure at least one member of each heterogeneous set.
+Measure at least 10\% of each heterogeneous set for Level~1, and at least \frac{1}{8} of each heterogeneous set for Level~2.
+Then, extrapolate the total power per each heterogeneous set as you would do for a non heterogeneous cluster.
+Finally, accumulate the contributions of all heterogeneous sets.
 \wl
 
 \noindent
@@ -575,8 +581,7 @@ consumed by $ \frac{1}{2} $ of the A compute nodes and $ \frac{1}{4} $ of the B 
 The total power measurement reported for compute nodes would then be 
 
 \noindent
-\[ Total~power=2*(power~from~compute~nodes~A) 
-                              + 4*(power~from~compute~nodes~B) \]
+\[ Total~power=2*(power~from~compute~nodes~A) + 4*(power~from~compute~nodes~B) \]
 
 \noindent
 The assumption of Levels 2 and 1 is that all the compute nodes in a set react identically to the workload.

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -254,7 +254,7 @@ The reported measurements. This aspect describes how the power measurements are 
 \end{itemize}
 
 \noindent
-For all required measurements, the submission must also include the data used to calculate them. For Level~2 and Level~3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core of the run. 
+For all required measurements, the submission must also include the data used to calculate them. For Level~2 and Level~3 submissions, the supporting data must include at least 10 measurement values at a regular sampling rate in the core phase of the run. 
 \wl
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -85,6 +85,8 @@ Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented
 \subsection{Power-Averaged and Total Energy Measurements}
 \label{sec:PAaTEM}
 
+This subsection describes the difference of power-averaged measurements as required for level 1 and level 2 as compared to total energy measurements as required for level 3.
+
 \subsubsection{Power-Averaged Measurements}
 
 \noindent

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -46,7 +46,7 @@ Levels 1 and 2 specify power measurements. Level 3 specifies an energy measureme
 
 \subsection{Sampling}
 \noindent
-For Levels 1 and 2, power measurements must be sampled at a constant frequency at least once per second.
+For Levels 1 and 2, the power meter must internally sample the instantaneous power at a constant frequency of at least once per second.
 The actual measurements that constitute a sample may be taken much more frequently than once per second.
 Usually the net frequency varies by a small percentage around 50~Hz or 60~Hz.
 It is allowed that the measurement frequency is not strictly constant, but it can be adjusted such that each sample interval covers a certain number of full sinus waves.
@@ -68,46 +68,43 @@ Refer to Section~\ref{sec:A3SIiIP} Aspect 3: Subsystems Included in Instrumented
 \subsubsection{Power-Averaged Measurements}
 
 \noindent
-The reported power values for Levels 1 and 2 are power-averaged measurements.
-A power-averaged measurement is one taken by a device that samples the instantaneous power used by a system at some fine time resolution for a given interval.
-The power-averaged measurement for the interval is the numerical average of all the instantaneous power measurements during that interval and constitutes one reported measurement covering that interval. 
-We require that the sampling frequncy must be at least 1 Hz and constant.
+The reported power values for Levels 1 and 2 are power-averaged measurements over a certain time period (e.g. the core phase or the full run).
+A power-averaged measurement is one taken by a device that samples the instantaneous power used by a system at some fine time resolution for a specified interval.
+The power meter device numerically averages of all the instantaneous power measurements sampled during that interval.
+This constitutes one reported measurement covering that interval.
+Finally, the power-averaged measurement for the required time period is the average of the power measurements obtained from the device in that period.
+All power readings reported by the device for that period must be used except for one case:
+Exclude those readings for intervals that do not lie completely in the requested time period.
+We require that the internal device sampling frequncy must be at least 1 Hz and constant.
+Also the measurement intervals must be of constant length and no longer than 10 seconds.
 As noted in the previous subsection, the frequency may vary slightly to accomodate for variations in the net frequency.
-In that case, the samples must be weighted according to the sample intervals.
+In that case, the averaging process must weight the power readings from the power meter according to the respective interval lengths.
+\wl
+
+\noindent
+For instance, a meter may sample internally at 1 Hz and report one power reading every 5 seconds.
+Then, the measurement of the core phase is the average of all these power readings obtained every 5 seconds.
 \wl
 
 \noindent
 Consider Level 1, which requires only one reported power value. 
-This reported power value may consist of several power measurements taken at a constant frequency of at least once per second and averaged over an interval. 
-For Level 1, this interval must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
-For example, if power measurements are taken once per second and the core phase takes 10 minutes, Level 1 reports one power-averaged value that averages over 600 samples.
+This reported power value may consist of several power measurements taken at a constant frequency of at least once per second and averaged over an interval.
+For Level 1, the time period that is measured must be the core phase of the run, which must be at least one minute long (see \ref{sec:core_phase} for definition of core phase).
+For example, if the device reports one power measurement every 5 seconds (each being the average of at least 5 power samples) and the core phase takes 10 minutes, Level 1 reports one power-averaged value that averages over all the 120 measurements obtained during the core phase.
 \wl
 
 \noindent
-Level 2 also requires that power measurements be taken at a constant frequency at least once per second.
+Level 2 also requires that power measurements be taken at a constant frequency and device must internally sample at least once per second.
 It requires the submission of the power-averaged measurement for the core phase, for the full run, and for a series of equally spaced power-averaged measurements of equal length during the full run.
-These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
-Each of the required equally spaced measurements required for Level 2 must power-average over the entire separating space.
-Alternatively, instead of the 10 power-averaged measurements, it is allowed to submit the full set of measured power samples which are used to calculate the power during the core phase and during the full run.
+These power-averaged measurements in the series must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload.
+There must not be any delay between the power measurement in this series and they must cover the entire core phase.
+Alternatively, instead of the 10 power-averaged measurements, it is allowed to submit the full set of power readings from the device that are used to calculate the average power during the core phase and during the full run.
 \wl
 
 \noindent
 The measurement for the core phase is identical to the measurement in Level 1.
-Assume again one sample per second, a core phase of 10 minutes and a full run of 15 minutes.
-In that case, the submission includes one power-averaged measurement over 600 samples for the core phase, one power-averaged measurement over 900 samples for the full run, and for instance a series of 15 power-averaged measurements over 60 samples every minute.
-Each of the required equally spaced measurements in the series must power-average over the entire separating space.
-\wl
-
-\noindent
-All the values reported by the meter must be used in the calculation.
-\wl
-
-\noindent
-For example, the meter may sample at one-second intervals and report a value every minute. Assume that the core phase is 600 minutes long. Assume further that the requirement for 10 equally spaced measurements can be satisfied with 10 measurements spaced 50 minutes apart. Using just those 10 measurements does not conform to this specification because all the values reported by the meter during the core phase are not used. 
-\wl
-
-\noindent
-Although those two measurements were equally spaced over 500 minutes , each averaged only over a minute. So some (the majority) of the separating space between the measurements was not included in the average. 
+Assume again one measurement every 5 seconds (consisting of 5 samples each), a core phase of 10 minutes and a full run of 15 minutes.
+In that case, the submission includes one power-averaged measurement over 120 power readings for the core phase, one power-averaged measurement over 180 readings for the full run, and for instance a series of 15 power-averaged measurements over 12 power readings each, once per minute.
 \wl
 
 \noindent
@@ -121,9 +118,14 @@ Level 3 specifies a total energy measurement that, when divided by the measured 
 \wl
 
 \noindent
-Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed time between the initial and final energy readings in the core phase.
+Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
 These last and first measurements in the core phase must be timed such that no more than a total of two seconds (one each at begin and end) of the core phase are not covered by the total energy measurement.
-The final average power value for the core phase is the difference between the initial and final energy readings divided by the elapsed time.
+The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
+The final value for the full run must be obtained analogously.
+\wl
+
+\noindent
+The difference between the initial and final energy readings are the total energy measurement in joule. The reported values after the energy has been divided by the elapsed time are watts as for levels 1 and 2.
 
 \section{Aspect and Quality Levels}
 \label{sec:AQLevels}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -23,7 +23,6 @@ Sections~\ref{sec:AQLevels} and \ref{sec:A1GTRM}. This section defines meter acc
 
 \noindent
 For Level 3, it is required to use any revenue grade meter, any meter accepted by spec power, or any meter documented to have an accuracy of 1\% or better. 
-Revenue grade meters are defined by ANSI C12.20.  
 Level 2 requires a meter with a minimum documented accuracy of 2\%.
 Level 1 requires a meter with a minimum documented accuracy of 5\%.
 \wl
@@ -50,14 +49,15 @@ In other words, you can use a single meter with 1\% accuracy, 4 meters with 2\% 
 \wl
 
 \noindent
+Revenue grade meters are defined by ANSI C12.20.
 For meters accepted by the spec power, refer to the {\itshape Power and Temperature Measurement Setup Guide \/} and the list of accepted power measurement devices from the Standard Performance Evaluation Corporation.
-\wl
-
-\noindent
+\begin{packed_item}
+\item 
 \url{http://www.spec.org/power_ssj2008/}
-
-\noindent
+\item
 \url{http://www.spec.org/power/docs/SPECpower-Device_List.html }
+\end{packed_item}
+\wl
 
 \section{Measuring Device Terminology}
 \label{sec:MDTerm}

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -431,9 +431,10 @@ Level 3 requires that the entire machine be measured. Level 2 requires a higher 
 \wl
 
 \noindent
+Levels 1 and 2 do not measure the power of the entire system, but require only a measurement of a fraction of the system and estimate the total power consumotion by extrapolation.
 When calculating the average power of the full machine for Levels 1 and 2, the measured power must be divided by this fraction to 
-estimate the average power drawn by the whole machine. For example, if the submitter measures the power delivered 
-to $ \frac{1}{4} $ of the machine, the submitter must then multiply the measured power by 4 to estimate power for the whole machine.  
+extrapolate to the average power drawn by the whole machine. For example, if the submitter measures the power delivered 
+to $ \frac{1}{4} $ of the machine, the submitter must then multiply the measured power by 4 to obtain the power for the whole machine.  
 The higher machine fractions are required at the higher quality levels to reduce the effects of random fluctuations and minor differences in hardware influencing the power measurements.  The larger the sample, the more transients will tend to cancel out.
 \wl
 

--- a/text/reporting.tex
+++ b/text/reporting.tex
@@ -151,7 +151,6 @@ Level~3 specifies a total energy measurement that, when divided by the measured 
 \wl
 
 \noindent
-<<<<<<< 2e6c0c1b4d5155ec37469b3883dc8710baf352da
 Level 3 reports an average power value for the core phase, an average power value for the whole run, at least 10 equally spaced energy values within the core phase, and the elapsed times between the first and last energy readings in both the core phase and the full run.
 These last and first measurements in the core phase must be timed such that no more than a total of ten seconds (five each at begin and end) of the core phase are not covered by the total energy measurement.
 The final average power value for the core phase is the difference between the first and last energy readings divided by the elapsed time between first and last reading.
@@ -183,8 +182,8 @@ Continuously integrated energy\\
 
 \textbf{1b:~Timing} &
 The entire core phase of the run, at least one minute &
-Equally spaced across the full run &
-Equally spaced across the full run   \\
+At equal intervals across the full run &
+At equal intervals across the full run   \\
 \hline
 
 \textbf{1c:~Measurements} &
@@ -206,7 +205,6 @@ $\bullet$ idle power \\
 \hline
 
 \textbf{2: Machine \newline fraction}  &
-<<<<<<< aeb65cd8bd3a9fbf4dbe4afeb92239ca0103e6c5
 The greater of 1/10 of the compute subsystem or 2~kW or 15~compute nodes. Alternatively at least 40~kW or the entire system. &
 The greater of 1/8 of the compute-node subsystem or 10~kW or 15~compute nodes &
 The whole of all included subsystems \\
@@ -360,7 +358,7 @@ least one minute long.
 
 \subsection{Level 2}
 \noindent
-Level 2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run. The workload run must have a series of equally spaced power-averaged measurements of equal length. These power-averaged measurements must be spaced close enough so that at least 10 measurements are reported during the core phase of the workload. The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.  
+Level 2 submissions include a measurement of the average power during the core phase of the run and the average power during the full run. The workload run must have a series of power-averaged measurements at constant time intervals. These measurement intervals must be short enough so that at least 10 measurements are reported during the core phase of the workload. The reported average power for the core phase of the run will be the numerical average of the 10 (or more) power-averaged measurements collected during the core phase.  
 \wl
 
 \noindent
@@ -402,7 +400,7 @@ The measuring device must sample voltage and current, whether AC or DC, at least
 \wl
 
 \noindent
-The reported total energy readings must be spaced so that at least 10 reported readings fall within the core phase of the workload. Note that each reported reading is the average of many samples.
+The intervals at which total energy readings are reported must be short enough so that at least 10 reported readings fall within the core phase of the workload. Note that each reported reading is the average of many samples.
 \wl
 
 


### PR DESCRIPTION
- Improve text a lot
- Remove obsolete parts and figures.
- Relax requirements for level 1, such that 40kw are enough in any case.
- Rewrite requirements for level 2 and disentangle the core phase and full run measurements with respect to the 10 power averaged measurements.
- Add accuracy requirements to the 4th aspect.
- Clarify that estimating power means substituting by upper bound.
- A measurement that qualifies for a higher level in one aspect automatically also qualifies for a lower level.
- Change accuracy requirements of power meters as discussed with Natalie and Paul.
- Rewrite and clarify the text about power measurement samples.
- Add a requirement on the maximum interval between power measurements reported by the power meter (should be short compared to the core phase).

Now include pull request 83 "Various improvements of the text". This was rebased onto here, so it can be merged.

Fixes #81
Fixes #80
Fixes #77
Fixes #75
Fixes #74
Fixes #65
Fixes #63
Fixes #62
Fixes #56
Fixes #82
Fixes #66 
